### PR TITLE
Feat/difficulty scaling dungeon generation refinement

### DIFF
--- a/flashcard-roguelike/game/entity/battle/BattleManager.cs
+++ b/flashcard-roguelike/game/entity/battle/BattleManager.cs
@@ -19,6 +19,9 @@ public partial class BattleManager : Node
 	private BattleTransition _transition;
 	private BattleUI _battleUI;
 	private FlashcardChallenge _flashcardChallenge;
+	private FlashcardChallengeTrueOrFalse _flashcardChallengeTrueOrFalse;
+	private FlashcardChallengeMultipleChoice _flashcardChallengeMultipleChoice;
+	private FlashcardChallengeManager _flashcardChallengeManager;
 	
 	// Cooldown management
 	private Timer _battleCooldownTimer;
@@ -45,15 +48,26 @@ public partial class BattleManager : Node
 		_flashcardChallenge = GD.Load<PackedScene>("res://game/ui/battle_ui/flashcard_challenge.tscn").Instantiate<FlashcardChallenge>();
 		AddChild(_flashcardChallenge);
 
-		if (_transition == null || _battleUI == null || _flashcardChallenge == null)
+		_flashcardChallengeTrueOrFalse = GD.Load<PackedScene>("res://game/ui/battle_ui/flashcard_challenge_true_false.tscn").Instantiate<FlashcardChallengeTrueOrFalse>();
+		AddChild(_flashcardChallengeTrueOrFalse);
+
+		_flashcardChallengeMultipleChoice = GD.Load<PackedScene>("res://game/ui/battle_ui/flashcard_challenge_multiple_choice.tscn").Instantiate<FlashcardChallengeMultipleChoice>();
+		AddChild(_flashcardChallengeMultipleChoice);
+
+		if (_transition == null || _battleUI == null || _flashcardChallenge == null || _flashcardChallengeTrueOrFalse == null || _flashcardChallengeMultipleChoice == null)
 		{
 			GD.PrintErr("BattleManager: Failed to load one or more UI scenes.");
 		}
 
+		// Initialize challenge manager
+		_flashcardChallengeManager = new FlashcardChallengeManager();
+		_flashcardChallengeManager.Initialize(_flashcardChallenge, _flashcardChallengeTrueOrFalse, _flashcardChallengeMultipleChoice);
+		_flashcardChallengeManager.SetAnswerSubmittedCallback(OnFlashcardAnswered);
+
 		// Initialize manager dependencies
 		_uiCoordinator.Initialize(_battleUI, _state);
 		_turnController.Initialize(_state, _uiCoordinator, _combatResolver);
-		_combatResolver.Initialize(_state, _uiCoordinator, _flashcardChallenge, _turnController);
+		_combatResolver.Initialize(_state, _uiCoordinator, _flashcardChallengeManager, _turnController);
 
 		// Connect UI signals
 		if (_battleUI != null)

--- a/flashcard-roguelike/game/entity/battle/battle_manager_helpers/CombatResolver.cs
+++ b/flashcard-roguelike/game/entity/battle/battle_manager_helpers/CombatResolver.cs
@@ -8,33 +8,34 @@ public class CombatResolver
 {
     private BattleState _state;
     private BattleUICoordinator _uiCoordinator;
-    private FlashcardChallenge _flashcardChallenge;
+    private FlashcardChallengeManager _flashcardChallengeManager;
     private TurnController _turnController;
     
     public event Action<bool> OnBattleEnded; // bool: victory
     public event Action<bool> OnBattleEndedWithRun; // bool: successfully ran
     
     public void Initialize(BattleState state, BattleUICoordinator uiCoordinator, 
-        FlashcardChallenge flashcardChallenge, TurnController turnController)
+        FlashcardChallengeManager flashcardChallengeManager, TurnController turnController)
     {
         _state = state;
         _uiCoordinator = uiCoordinator;
-        _flashcardChallenge = flashcardChallenge;
+        _flashcardChallengeManager = flashcardChallengeManager;
         _turnController = turnController;
     }
     
     // Start attack sequence with flashcard challenge
     public void StartAttackSequence()
     {
-        if (_flashcardChallenge != null)
+        float difficulty = GameDifficultyManager.Instance.getCurrentDifficultyScore();
+        if (_flashcardChallengeManager != null)
         {
             // Load a random flashcard for the attack challenge
-            Flashcard card = _flashcardChallenge.LoadRandomCard();
+            Flashcard card = _flashcardChallengeManager.LoadRandomCard();
             if (card != null)
             {
-                // Set state to wait for flashcard answer and show challenge
+                // Set state to wait for flashcard answer and show challenge with difficulty
                 _state.WaitingForFlashcard = true;
-                _flashcardChallenge.ShowChallenge(card, "Answer correctly to attack!");
+                _flashcardChallengeManager.ShowChallenge(card, "Answer correctly to attack!", difficulty);
             }
             else
             {
@@ -45,8 +46,8 @@ public class CombatResolver
         }
         else
         {
-            // If flashcard challenge UI is not assigned, log an error and execute attack as if it succeeded, shouldnt happen
-            GD.PrintErr("CombatResolver: FlashcardChallenge is not assigned. Skipping attack challenge.");
+            // If flashcard challenge manager is not assigned, log an error and execute attack as if it succeeded, shouldnt happen
+            GD.PrintErr("CombatResolver: FlashcardChallengeManager is not assigned. Skipping attack challenge.");
             ExecutePlayerAttack(true);
         }
     }
@@ -56,15 +57,15 @@ public class CombatResolver
     {
         _state.PendingAction = "defend";
         
-        if (_flashcardChallenge != null)
+        if (_flashcardChallengeManager != null)
         {
             // Load a random flashcard for the defense challenge
-            Flashcard card = _flashcardChallenge.LoadRandomCard();
+            Flashcard card = _flashcardChallengeManager.LoadRandomCard();
             if (card != null)
             {
-                // Set state to wait for flashcard answer and show challenge
+                // Set state to wait for flashcard answer and show challenge with default difficulty (0 = text)
                 _state.WaitingForFlashcard = true;
-                _flashcardChallenge.ShowChallenge(card, "Answer correctly to defend!");
+                _flashcardChallengeManager.ShowChallenge(card, "Answer correctly to defend!", 0);
             }
             else
             {
@@ -75,8 +76,8 @@ public class CombatResolver
         }
         else
         {
-            // If flashcard challenge UI is not assigned, log an error and execute attack as if defense failed, shouldnt happen
-            GD.PrintErr("CombatResolver: FlashcardChallenge is not assigned. Skipping defense challenge.");
+            // If flashcard challenge manager is not assigned, log an error and execute attack as if defense failed, shouldnt happen
+            GD.PrintErr("CombatResolver: FlashcardChallengeManager is not assigned. Skipping defense challenge.");
             ExecuteEnemyAttack(false);
         }
     }

--- a/flashcard-roguelike/game/entity/dungeon_generator/DungeonGenerator.cs
+++ b/flashcard-roguelike/game/entity/dungeon_generator/DungeonGenerator.cs
@@ -21,21 +21,21 @@ public partial class DungeonGenerator : Node3D
 
 	private readonly RandomNumberGenerator _rng = new RandomNumberGenerator();
 
-	// Move stuff from Ready to a separate GenerateDungeon method that can be called 
-	// whenever we want to generate a new dungeon, such as when the player enters a new floor or restarts after death.
-	// Everytime we generate the graph, each room should be assigned a difficulty rating from the 
-	// difficulty singleton. This determins the amount of enemies in combat rooms, the quality of loot in treasure rooms, 
-	// and the difficulty of flashcard challenges in event rooms. Difficulty can be assigned in the 
-	// spawn rooms method, and can be stored in the DungeonRoom class as a property. 
-	// This way, the difficulty of each room can be easily accessed when spawning the room and its contents, 
-	// and can also be used by the UI to display the difficulty of each room to the player.
-	public override void _Ready()
-	{
-		DungeonGraph graph = GenerateGraph(); // Generate the dungeon graph structure
+    // Move stuff from Ready to a separate GenerateDungeon method that can be called 
+    // whenever we want to generate a new dungeon, such as when the player enters a new floor or restarts after death.
+    // Everytime we generate the graph, each room should be assigned a difficulty rating from the 
+    // difficulty singleton. This determins the amount of enemies in combat rooms, the quality of loot in treasure rooms, 
+    // and the difficulty of flashcard challenges in event rooms. Difficulty can be assigned in the 
+    // spawn rooms method, and can be stored in the DungeonRoom class as a property. 
+    // This way, the difficulty of each room can be easily accessed when spawning the room and its contents, 
+    // and can also be used by the UI to display the difficulty of each room to the player.
+    public override void _Ready()
+    {
+        DungeonGraph graph = GenerateGraph(); // Generate the dungeon graph structure
 		graph.PrintGraph();
 		Dictionary<int, Vector3> positions = GenerateLayout(graph); // Generate world positions for rooms
 		SpawnRooms(graph, positions); // Instantiate room scenes and connections based on the graph and layout
-	}
+    }
 
 	public DungeonGraph GenerateGraph()
 	{
@@ -60,8 +60,6 @@ public partial class DungeonGenerator : Node3D
 
 		// Create the dungeon graph with the specified number of rooms and minimum room type requirements
 		DungeonGraph graph = new DungeonGraph(roomCount, MinCombatRooms, MinEventRooms, MinTreasureRooms);
-
-		// Connect rooms ensuring that all rooms are reachable from the entrance
 		HashSet<int> connected = new HashSet<int> { 0 }; // Start with entrance
 		List<int> toConnect = new List<int>();
 
@@ -79,12 +77,6 @@ public partial class DungeonGenerator : Node3D
 			int destIndex = _rng.RandiRange(0, toConnect.Count - 1);
 			int to = toConnect[destIndex];
 
-			// Ensure exits don't go out, and entrances don't allow in
-			if (graph.GetRoom(from).RoomType == RoomTypes.Exit || graph.GetRoom(to).RoomType == RoomTypes.Entrance)
-			{
-				continue;
-			}
-
 			// Try to connect the rooms, and if successful move the room from toConnect to connected
 			if (graph.TryConnect(from, to, MaxConnections))
 			{
@@ -93,6 +85,7 @@ public partial class DungeonGenerator : Node3D
 			}
 		}
 
+		/* Keep commented out for now to more easily see the graph
 		// Add some extra random connections for more interconnectivity and non-linearity
 		int targetExtraEdges = roomCount / 3; 
 		int attempts = roomCount * roomCount / 2; 
@@ -109,6 +102,7 @@ public partial class DungeonGenerator : Node3D
 				added++;
 			}
 		}
+		*/
 
 		// Check if all rooms are reachable from the entrance and print a warning if not. 
 		if (!graph.AreAllRoomsReachable())
@@ -294,9 +288,10 @@ public partial class DungeonGenerator : Node3D
 
 	private void ClearChildren(Node root)
 	{
-		// Clear all children of this root node
+		// Clear all children of this root node immediately to prevent issues with stale connections
 		foreach (Node child in root.GetChildren())
 		{
+			root.RemoveChild(child);
 			child.QueueFree();
 		}
 	}

--- a/flashcard-roguelike/game/entity/dungeon_generator/DungeonGenerator.cs
+++ b/flashcard-roguelike/game/entity/dungeon_generator/DungeonGenerator.cs
@@ -205,7 +205,28 @@ public partial class DungeonGenerator : Node3D
 			roomNode.AddChild(label);
 			
 			// Add the room to the Rooms node in the scene tree
-			roomsRoot.AddChild(roomNode);		
+			roomsRoot.AddChild(roomNode);	
+
+			// If it is a combat room, spawn enemies randomly in the enemy area node based off difficulty
+			if (room.RoomType == RoomTypes.Combat)
+			{
+				int enemyCount = GameDifficultyManager.Instance.getEnemyCount();
+				var enemyNode = roomNode.GetNodeOrNull<Node3D>("Enemies");
+				List<Marker3D> spawnPoints = roomNode.GetNodeOrNull<Node3D>("EnemySpawnArea").GetChildren().OfType<Marker3D>().ToList();
+
+				for (int i = 0; i < enemyCount; i++)
+				{
+					// For testing purposes we will just spawn generic enemy instances at random positions in the enemy area
+					// In the future, we can use the difficulty score to determine the type and strength of enemies to spawn
+					// Maybe we define a list of enemies somewhere with associated difficulty ratings
+					EnemyExample enemyInstance = GD.Load<PackedScene>("res://game/entity/enemy_example/enemy_example.tscn").Instantiate() as EnemyExample;
+					enemyInstance.Name = $"Enemy_{i}";
+					enemyNode.AddChild(enemyInstance);
+					enemyInstance.GlobalPosition = spawnPoints[i].GlobalPosition;
+				}
+
+				GD.Print($"Spawned {enemyCount} enemies in Room {room.Id} based on difficulty score of {GameDifficultyManager.Instance.getCurrentDifficultyScore()}.");
+			}	
 		}
 	}
 

--- a/flashcard-roguelike/game/entity/dungeon_generator/DungeonGenerator.cs
+++ b/flashcard-roguelike/game/entity/dungeon_generator/DungeonGenerator.cs
@@ -1,12 +1,15 @@
 using Godot;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 public partial class DungeonGenerator : Node3D
 {
 	[Export] public int MaxRoomCount = 8;
 	[Export] public int MaxConnections = 4;
-	[Export] public int MaxExtraConnections = 1;
+	[Export] public int MinCombatRooms = 1;
+	[Export] public int MinEventRooms = 1;
+	[Export] public int MinTreasureRooms = 1;
 	[Export] public bool UseRandomSeed = true;
 	[Export] public int Seed = 1234;
 	[Export] public PackedScene EntranceRoomScene;
@@ -18,16 +21,25 @@ public partial class DungeonGenerator : Node3D
 
 	private readonly RandomNumberGenerator _rng = new RandomNumberGenerator();
 
+	// Move stuff from Ready to a separate GenerateDungeon method that can be called 
+	// whenever we want to generate a new dungeon, such as when the player enters a new floor or restarts after death.
+	// Everytime we generate the graph, each room should be assigned a difficulty rating from the 
+	// difficulty singleton. This determins the amount of enemies in combat rooms, the quality of loot in treasure rooms, 
+	// and the difficulty of flashcard challenges in event rooms. Difficulty can be assigned in the 
+	// spawn rooms method, and can be stored in the DungeonRoom class as a property. 
+	// This way, the difficulty of each room can be easily accessed when spawning the room and its contents, 
+	// and can also be used by the UI to display the difficulty of each room to the player.
 	public override void _Ready()
 	{
-		DungeonGraph graph = GenerateGraph();
+		DungeonGraph graph = GenerateGraph(); // Generate the dungeon graph structure
 		graph.PrintGraph();
-		Dictionary<int, Vector3> positions = GenerateLayout(graph);
-		SpawnRooms(graph, positions);
+		Dictionary<int, Vector3> positions = GenerateLayout(graph); // Generate world positions for rooms
+		SpawnRooms(graph, positions); // Instantiate room scenes and connections based on the graph and layout
 	}
 
 	public DungeonGraph GenerateGraph()
 	{
+		// Initialize random number generator with seed
 		if (UseRandomSeed)
 		{
 			_rng.Randomize();
@@ -37,43 +49,75 @@ public partial class DungeonGenerator : Node3D
 			_rng.Seed = (ulong)Seed;
 		}
 
-		int roomCount = _rng.RandiRange(4, MaxRoomCount);
-		DungeonGraph graph = new DungeonGraph(roomCount);
+		// Ensure that MaxRoomCount is sufficient to accommodate the minimum required rooms
+		int minRoomCount = MinCombatRooms + MinEventRooms + MinTreasureRooms + 2; // +2 for entrance and exit
+		if (MaxRoomCount < minRoomCount)
+		{
+			GD.PushError($"MaxRoomCount must be at least {minRoomCount} to accommodate the minimum required rooms. Adjusting MaxRoomCount to {minRoomCount}.");
+			MaxRoomCount = minRoomCount;
+		}
+		int roomCount = _rng.RandiRange(minRoomCount, MaxRoomCount);
 
-		List<int> connected = new List<int>();
+		// Create the dungeon graph with the specified number of rooms and minimum room type requirements
+		DungeonGraph graph = new DungeonGraph(roomCount, MinCombatRooms, MinEventRooms, MinTreasureRooms);
+
+		// Connect rooms ensuring that all rooms are reachable from the entrance
+		HashSet<int> connected = new HashSet<int> { 0 }; // Start with entrance
 		List<int> toConnect = new List<int>();
 
-		for (int i = 0; i < roomCount; i++)
+		// Initially, all rooms except the entrance are in the toConnect list
+		for (int i = 1; i < roomCount; i++)
 		{
 			toConnect.Add(i);
 		}
 
+		// Connect every room to at least one other room, ensuring connectivity from the entrance
 		while (toConnect.Count > 0)
 		{
-			int a = connected.Count <= 0 ? 0 : connected[_rng.RandiRange(0, connected.Count - 1)];
+			// Randomly select a from room from the connected set and a to room from the toConnect list
+			int from = connected.Count <= 0 ? 0 : connected.ElementAt(_rng.RandiRange(0, connected.Count - 1));
 			int destIndex = _rng.RandiRange(0, toConnect.Count - 1);
-			int b = toConnect[destIndex];
+			int to = toConnect[destIndex];
 
-			if (graph.TryConnect(a, b, MaxConnections))
+			// Ensure exits don't go out, and entrances don't allow in
+			if (graph.GetRoom(from).RoomType == RoomTypes.Exit || graph.GetRoom(to).RoomType == RoomTypes.Entrance)
 			{
-				connected.Add(b);
+				continue;
+			}
+
+			// Try to connect the rooms, and if successful move the room from toConnect to connected
+			if (graph.TryConnect(from, to, MaxConnections))
+			{
+				connected.Add(to);
 				toConnect.RemoveAt(destIndex);
 			}
 		}
 
-		int targetExtraEdges = _rng.RandiRange(0, MaxExtraConnections);
-		int attempts = roomCount * roomCount / 2;
+		// Add some extra random connections for more interconnectivity and non-linearity
+		int targetExtraEdges = roomCount / 3; 
+		int attempts = roomCount * roomCount / 2; 
 		int added = 0;
 
+		// Randomly connect rooms until we reach the target number of extra edges or exhaust attempts to prevent infinite loops
 		while (added < targetExtraEdges && attempts-- > 0)
 		{
-			int a = _rng.RandiRange(0, roomCount - 1);
-			int b = _rng.RandiRange(0, roomCount - 1);
+			int from = _rng.RandiRange(0, roomCount - 1);
+			int to = _rng.RandiRange(0, roomCount - 1);
 
-			if (graph.TryConnect(a, b, MaxConnections))
+			if (graph.TryConnect(from, to, MaxConnections))
 			{
 				added++;
 			}
+		}
+
+		// Check if all rooms are reachable from the entrance and print a warning if not. 
+		if (!graph.AreAllRoomsReachable())
+		{
+			GD.PushWarning("Not all rooms are reachable in the generated dungeon graph.");
+		}
+		else
+		{
+			GD.Print("All rooms are reachable in the generated dungeon graph.");
 		}
 
 		return graph;
@@ -86,9 +130,11 @@ public partial class DungeonGenerator : Node3D
 
 	private Dictionary<int, Vector3> GenerateLayout(DungeonGraph graph)
 	{
+		// We place rooms in a line since they are not physically connected and we want to avoid overlapping.
 		int roomCount = graph.Rooms.Count;
 		Dictionary<int, Vector3> positions = new Dictionary<int, Vector3>(roomCount);
 
+		// Place each at a fixed distance apart on the x-axis.
 		for (int i = 0; i < roomCount; i++)
 		{
 			positions[i] = new Vector3(i * 100f, 0, 0);
@@ -99,14 +145,18 @@ public partial class DungeonGenerator : Node3D
 
 	private void SpawnRooms(DungeonGraph graph, Dictionary<int, Vector3> positions)
 	{
+		// Get Rooms node and clear exisiting rooms for regeneration.
 		Node3D roomsRoot = GetOrCreateRoot("Rooms");
 		ClearChildren(roomsRoot);
 
+		// Instantiate each room and its connections based on the graph structure and the generated layout.
 		foreach (DungeonRoom room in graph.Rooms)
-		{
+		{	
+			// Create a new room node and set its postition
 			Node3D roomNode = CreateRoomNode(room.Id, room.RoomType);
 			roomNode.Position = positions[room.Id];
 			
+			// Get the entrances and exits nodes and check for null
 			Node3D entrances = roomNode.GetNodeOrNull<Node3D>("Entrances");
 			Node3D exits = roomNode.GetNodeOrNull<Node3D>("Exits");
 
@@ -119,43 +169,55 @@ public partial class DungeonGenerator : Node3D
 				continue;
 			}
 
-			foreach (int origin in room.IncomingConnections)
+			// Instantiate incoming connections for the room
+			foreach (int incoming in room.IncomingConnections)
 			{
 				PackedScene conn = ConnectionScene;
 				RoomConnection connInstance = conn.Instantiate() as RoomConnection;
-				connInstance.TargetRoomId = origin;
+				connInstance.TargetRoomId = incoming;
 				connInstance.IsEntrance = true;
-				connInstance.SetLabel(true, origin, graph.GetRoom(origin).RoomType.ToString());
+				// Set the label to show the source room ID and type for debugging purposes
+				connInstance.SetLabel(true, incoming, graph.GetRoom(incoming).RoomType.ToString());
+				// Add the connection to this room's entrances
 				entrances.GetChildOrNull<Marker3D>(entranceIndex++)?.AddChild(connInstance);
 				connInstance.connection_enabled = true;
 			}
 
-			foreach (int destination in room.OutgoingConnections)
+			// Instantiate outgoing connections for the room
+			foreach (int outgoing in room.OutgoingConnections)
 			{
 				PackedScene conn = ConnectionScene;
 				RoomConnection connInstance = conn.Instantiate() as RoomConnection;
-				connInstance.TargetRoomId = destination;
+				connInstance.TargetRoomId = outgoing;
 				connInstance.IsEntrance = false;
-				connInstance.SetLabel(false, destination, graph.GetRoom(destination).RoomType.ToString());
+				// Set the label to show the target room ID and type for debugging purposes
+				connInstance.SetLabel(false, outgoing, graph.GetRoom(outgoing).RoomType.ToString());
+				// Add the connection to this room's exits
 				exits.GetChildOrNull<Marker3D>(exitIndex++)?.AddChild(connInstance);
-				if(room.RoomType == RoomTypes.Combat) { // Combat rooms are the only "gated" rooms for now 
+				if(room.RoomType == RoomTypes.Combat) 
+				{ 
+					// Combat rooms are the only "gated" rooms for now 
 					connInstance.connection_enabled = false;
 					connInstance.Visible = false; //Setting to true for testing purposes
 				}
 			}
 
+			// Add a label in the middle of the room to show its ID and type for debugging purposes
 			Label3D label = new Label3D();
 			label.Text = $"Room {room.Id} ({room.RoomType})";
 			label.Position = new Vector3(0, 3, 0);
 			label.Billboard = BaseMaterial3D.BillboardModeEnum.Enabled;
 			label.FontSize = 94;
 			roomNode.AddChild(label);
-			roomsRoot.AddChild(roomNode);
+			
+			// Add the room to the Rooms node in the scene tree
+			roomsRoot.AddChild(roomNode);		
 		}
 	}
 
 	private Node3D CreateRoomNode(int roomId, RoomTypes type)
 	{	
+		// Instantiate rooms based off the room type using switch statement
 		Node3D instance = null;
 		Node3D roomNode;
 
@@ -200,6 +262,7 @@ public partial class DungeonGenerator : Node3D
 				break;
 		}	
 
+		// Assign the instance and metadata, if null print a warning and free the instance to prevent memory leaks
 		roomNode = instance;
 
 		if (roomNode != null)
@@ -218,6 +281,7 @@ public partial class DungeonGenerator : Node3D
 	
 	private Node3D GetOrCreateRoot(string name)
 	{
+		// Get or create the root node with the given name
 		Node3D root = GetNodeOrNull<Node3D>(name);
 		if (root == null)
 		{
@@ -230,6 +294,7 @@ public partial class DungeonGenerator : Node3D
 
 	private void ClearChildren(Node root)
 	{
+		// Clear all children of this root node
 		foreach (Node child in root.GetChildren())
 		{
 			child.QueueFree();

--- a/flashcard-roguelike/game/entity/dungeon_generator/DungeonGraph.cs
+++ b/flashcard-roguelike/game/entity/dungeon_generator/DungeonGraph.cs
@@ -101,10 +101,37 @@ public sealed class DungeonGraph
 		DungeonRoom fromRoom = Rooms[from];
 		DungeonRoom toRoom = Rooms[to];
 
+		bool fromIsEntrance = fromRoom.RoomType == RoomTypes.Entrance;
+		bool toIsExit = toRoom.RoomType == RoomTypes.Exit;
+
+		// Prevent entrance from having too many outgoing connections, 2 for now
+		if (fromIsEntrance && fromRoom.OutgoingConnections.Count >= 2)
+		{
+			return false; 
+		}
+
+		// Prevent exit from having having too many incoming connections, 2 for now
+		if (toIsExit && toRoom.IncomingConnections.Count >= 2)
+		{
+			return false; 
+		}
+
+		// Prevent direct connection from entrance to exit
+		if (fromIsEntrance && toIsExit)
+		{
+			return false; 
+		}
+
+		// Ensure exits don't go out, and entrances don't allow in
+		if (fromRoom.RoomType == RoomTypes.Exit || toRoom.RoomType == RoomTypes.Entrance)
+		{
+			return false;
+		}
+
 		// Ensure rooms only go "deeper"
 		if (toRoom.Depth <= fromRoom.Depth)
 		{
-			return false; 
+			toRoom.Depth = fromRoom.Depth + 1; // Update depth to maintain proper layering
 		}
 
 		// Ensure rooms don't exceed max connections

--- a/flashcard-roguelike/game/entity/dungeon_generator/DungeonGraph.cs
+++ b/flashcard-roguelike/game/entity/dungeon_generator/DungeonGraph.cs
@@ -17,11 +17,14 @@ public sealed class DungeonRoom
 	public HashSet<int> IncomingConnections { get; } = new HashSet<int>();
 	public HashSet<int> OutgoingConnections { get; } = new HashSet<int>();
 	public RoomTypes RoomType { get; set; }
+	public int Depth { get; set; }
+	public float Difficulty { get; set; }
 
-	public DungeonRoom(int id, RoomTypes type)
+	public DungeonRoom(int id, RoomTypes type, int depth)
 	{
 		Id = id;
 		RoomType = type;
+		Depth = depth;
 	}
 }
 
@@ -29,8 +32,9 @@ public sealed class DungeonGraph
 {
 	public List<DungeonRoom> Rooms { get; }
 
-	public DungeonGraph(int roomCount)
+	public DungeonGraph(int roomCount, int minCombat = 1, int minEvent = 1, int minTreasure = 1)
 	{
+		// Initialize the dungeon graph with the specified number of rooms and minimum room type requirements
 		RoomTypes type;
 		Random rand = new Random();
 
@@ -40,16 +44,40 @@ public sealed class DungeonGraph
 		}
 
 		Rooms = new List<DungeonRoom>(roomCount);
-		Rooms.Add(new DungeonRoom(0, RoomTypes.Entrance)); // Ensure the first room is always an entrance
+		Rooms.Add(new DungeonRoom(0, RoomTypes.Entrance, 0)); // Ensure the first room is always an entrance
 
-		for (int i = 1; i < roomCount - 1; i++)
+		int availableRooms = roomCount - 2; // Exclude entrance and exit
+
+		// Add all minimum required rooms to the list first
+		List<RoomTypes> roomsToAdd = new List<RoomTypes>();
+		for (int i = 0; i < minCombat; i++) roomsToAdd.Add(RoomTypes.Combat);
+		for (int i = 0; i < minEvent; i++) roomsToAdd.Add(RoomTypes.Event);
+		for (int i = 0; i < minTreasure; i++) roomsToAdd.Add(RoomTypes.Treasure);
+
+		// Fill remaining rooms with random types
+		for (int i = roomsToAdd.Count; i < availableRooms; i++)
 		{
-			type = (RoomTypes)rand.Next(1, Enum.GetNames(typeof(RoomTypes)).Length - 1);
-			Rooms.Add(new DungeonRoom(i, type));
-			GD.Print($"Created room {i} of type {type}");
+			roomsToAdd.Add((RoomTypes)rand.Next(1, Enum.GetNames(typeof(RoomTypes)).Length - 1));
 		}
 
-		Rooms.Add(new DungeonRoom(roomCount - 1, RoomTypes.Exit)); // Ensure the last room is always an exit
+		// Shuffle the roomsToAdd list to randomize the order of room types
+		for (int i = roomsToAdd.Count - 1; i > 0; i--)
+		{
+			int j = rand.Next(i + 1);
+			// In-place swap of elements at indices i and j
+			(roomsToAdd[i], roomsToAdd[j]) = (roomsToAdd[j], roomsToAdd[i]);
+		}
+
+		// Add rooms to the graph based on the shuffled list
+		for (int i = 0; i < roomsToAdd.Count; i++)
+		{
+			type = roomsToAdd[i];
+			Rooms.Add(new DungeonRoom(i + 1, type, i + 1));
+			GD.Print($"Created room {i + 1} of type {type}");
+		}
+
+		// Ensure the last room is always an exit
+		Rooms.Add(new DungeonRoom(roomCount - 1, RoomTypes.Exit, roomCount - 1)); 
 	}
 
 	public DungeonRoom GetRoom(int id)
@@ -64,6 +92,7 @@ public sealed class DungeonGraph
 
 	public bool TryConnect(int from, int to, int maxConnections)
 	{
+		// If the rooms are the same stop
 		if (from == to)
 		{
 			return false;
@@ -72,11 +101,19 @@ public sealed class DungeonGraph
 		DungeonRoom fromRoom = Rooms[from];
 		DungeonRoom toRoom = Rooms[to];
 
+		// Ensure rooms only go "deeper"
+		if (toRoom.Depth <= fromRoom.Depth)
+		{
+			return false; 
+		}
+
+		// Ensure rooms don't exceed max connections
 		if (fromRoom.OutgoingConnections.Count >= maxConnections || toRoom.IncomingConnections.Count >= maxConnections)
 		{
 			return false;
 		}
 
+		// Ensure the connection doesn't already exist
 		if (fromRoom.OutgoingConnections.Contains(to))
 		{
 			return false;
@@ -99,5 +136,35 @@ public sealed class DungeonGraph
 		}
 
 		GD.Print("=====================");
+	}
+
+	public bool AreAllRoomsReachable()
+	{
+	    if (Rooms.Count == 0) return true;
+	
+	    HashSet<int> visited = new HashSet<int>();
+	    Queue<int> toVisit = new Queue<int>();
+	
+	    // Start from the entrance (room 0)
+	    toVisit.Enqueue(0);
+	    visited.Add(0);
+	
+	    // BFS traversal following outgoing connections
+	    while (toVisit.Count > 0)
+	    {
+	        int current = toVisit.Dequeue();
+	        DungeonRoom room = Rooms[current];
+	
+	        foreach (int nextRoomId in room.OutgoingConnections)
+	        {
+	            if (!visited.Contains(nextRoomId))
+	            {
+	                visited.Add(nextRoomId);
+	                toVisit.Enqueue(nextRoomId);
+	            }
+	        }
+	    }
+	
+	    return visited.Count == Rooms.Count;
 	}
 }

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/combat_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/combat_room.tscn
@@ -1,6 +1,5 @@
 [gd_scene format=4 uid="uid://b2px6jxwb8r7o"]
 
-[ext_resource type="PackedScene" uid="uid://b1awrh787m3pg" path="res://game/entity/enemy_example/enemy_example.tscn" id="1_14lci"]
 [ext_resource type="Script" uid="uid://bvi274x44ayaj" path="res://game/entity/dungeon_generator/rooms/Room.cs" id="1_os7nw"]
 [ext_resource type="PackedScene" uid="uid://dtutg34hih1q2" path="res://scenes/battle_scene/battle_area.tscn" id="2_p3pul"]
 
@@ -31,7 +30,7 @@ size = Vector3(50, 0.5, 50)
 [sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_j4xo5"]
 points = PackedVector3Array(-25, -0.25, -25, -25, 0.25, -25, 25, -0.25, -25, -25, -0.25, 25, -25, 0.25, 25, 25, 0.25, -25, 25, -0.25, 25, 25, 0.25, 25)
 
-[node name="EntranceRoom" type="Node3D" unique_id=1298955981]
+[node name="CombatRoom" type="Node3D" unique_id=1298955981]
 script = ExtResource("1_os7nw")
 
 [node name="Walls" type="MeshInstance3D" parent="." unique_id=1338685124]
@@ -56,8 +55,6 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.59409785, 16.44909)
 
 [node name="ExitPoint" type="Marker3D" parent="." unique_id=1595695969]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.44763565, -17.54694)
-
-[node name="EnemyExample" parent="." unique_id=592527612 instance=ExtResource("1_14lci")]
 
 [node name="BattleArea" parent="." unique_id=1408501426 instance=ExtResource("2_p3pul")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -10.02218, 0, 0)
@@ -91,3 +88,16 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.29
 
 [node name="3" type="Marker3D" parent="Exits" unique_id=1697339623]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, -7.2970276)
+
+[node name="Enemies" type="Node3D" parent="." unique_id=1545093645]
+
+[node name="EnemySpawnArea" type="Node3D" parent="." unique_id=1198793720]
+transform = Transform3D(1, 0, 0, 0, -4.371139e-08, 1, 0, -1, -4.371139e-08, 0, 0.36848903, -6.1300144)
+
+[node name="1" type="Marker3D" parent="EnemySpawnArea" unique_id=1107001417]
+
+[node name="2" type="Marker3D" parent="EnemySpawnArea" unique_id=695708602]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, 0)
+
+[node name="3" type="Marker3D" parent="EnemySpawnArea" unique_id=1252675369]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 0, 0)

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/combat_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/combat_room.tscn
@@ -1,7 +1,7 @@
 [gd_scene format=4 uid="uid://b2px6jxwb8r7o"]
 
 [ext_resource type="PackedScene" uid="uid://b1awrh787m3pg" path="res://game/entity/enemy_example/enemy_example.tscn" id="1_14lci"]
-[ext_resource type="Script" uid="uid://c8fl78a1ygu1q" path="res://game/entity/dungeon_generator/rooms/Room.cs" id="1_os7nw"]
+[ext_resource type="Script" uid="uid://bvi274x44ayaj" path="res://game/entity/dungeon_generator/rooms/Room.cs" id="1_os7nw"]
 [ext_resource type="PackedScene" uid="uid://dtutg34hih1q2" path="res://scenes/battle_scene/battle_area.tscn" id="2_p3pul"]
 
 [sub_resource type="ArrayMesh" id="ArrayMesh_j4xo5"]
@@ -57,37 +57,37 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.59409785, 16.44909)
 [node name="ExitPoint" type="Marker3D" parent="." unique_id=1595695969]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.44763565, -17.54694)
 
-[node name="Entrances" type="Node3D" parent="." unique_id=346511184]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 16.374111)
-
-[node name="0" type="Marker3D" parent="Entrances" unique_id=707015329]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, 4.9187107)
-
-[node name="1" type="Marker3D" parent="Entrances" unique_id=112222844]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, 4.9187107)
-
-[node name="2" type="Marker3D" parent="Entrances" unique_id=2120414536]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, 4.9187107)
-
-[node name="3" type="Marker3D" parent="Entrances" unique_id=59496419]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, 4.9187107)
-
-[node name="Exits" type="Node3D" parent="." unique_id=476148545]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -13.484043)
-
-[node name="0" type="Marker3D" parent="Exits" unique_id=162859324]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.2970276)
-
-[node name="1" type="Marker3D" parent="Exits" unique_id=1154018645]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, -7.2970276)
-
-[node name="2" type="Marker3D" parent="Exits" unique_id=454553864]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, -7.2970276)
-
-[node name="3" type="Marker3D" parent="Exits" unique_id=897839084]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, -7.2970276)
-
 [node name="EnemyExample" parent="." unique_id=592527612 instance=ExtResource("1_14lci")]
 
 [node name="BattleArea" parent="." unique_id=1408501426 instance=ExtResource("2_p3pul")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8.816615, 0, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -10.02218, 0, 0)
+
+[node name="Entrances" type="Node3D" parent="." unique_id=733062030]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 16.374111)
+
+[node name="0" type="Marker3D" parent="Entrances" unique_id=1178486331]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, 4.9187107)
+
+[node name="1" type="Marker3D" parent="Entrances" unique_id=1718334669]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, 4.9187107)
+
+[node name="2" type="Marker3D" parent="Entrances" unique_id=274300184]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, 4.9187107)
+
+[node name="3" type="Marker3D" parent="Entrances" unique_id=1069317128]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, 4.9187107)
+
+[node name="Exits" type="Node3D" parent="." unique_id=1524863286]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -13.484043)
+
+[node name="0" type="Marker3D" parent="Exits" unique_id=556900261]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, -7.2970276)
+
+[node name="1" type="Marker3D" parent="Exits" unique_id=843163160]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, -7.2970276)
+
+[node name="2" type="Marker3D" parent="Exits" unique_id=58254583]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.2970276)
+
+[node name="3" type="Marker3D" parent="Exits" unique_id=1697339623]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, -7.2970276)

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/entrance_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/entrance_room.tscn
@@ -29,7 +29,7 @@ size = Vector3(50, 0.5, 50)
 [sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_fij0k"]
 points = PackedVector3Array(-25, -0.25, -25, -25, 0.25, -25, 25, -0.25, -25, -25, -0.25, 25, -25, 0.25, 25, 25, 0.25, -25, 25, -0.25, 25, 25, 0.25, 25)
 
-[node name="EntranceRoom" type="Node3D" unique_id=1298955981]
+[node name="EntranceRoom2" type="Node3D" unique_id=1298955981]
 
 [node name="Walls" type="MeshInstance3D" parent="." unique_id=1011732479]
 mesh = SubResource("ArrayMesh_fij0k")
@@ -72,17 +72,11 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, 4.91871
 [node name="Exits" type="Node3D" parent="." unique_id=476148545]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -13.484043)
 
-[node name="0" type="Marker3D" parent="Exits" unique_id=162859324]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.2970276)
-
-[node name="1" type="Marker3D" parent="Exits" unique_id=1154018645]
+[node name="0" type="Marker3D" parent="Exits" unique_id=1154018645]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, -7.2970276)
 
-[node name="2" type="Marker3D" parent="Exits" unique_id=454553864]
+[node name="1" type="Marker3D" parent="Exits" unique_id=454553864]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, -7.2970276)
-
-[node name="3" type="Marker3D" parent="Exits" unique_id=897839084]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, -7.2970276)
 
 [node name="Player" parent="." unique_id=249236073 instance=ExtResource("1_fij0k")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.187, 5.766)

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/entrance_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/entrance_room.tscn
@@ -29,7 +29,7 @@ size = Vector3(50, 0.5, 50)
 [sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_fij0k"]
 points = PackedVector3Array(-25, -0.25, -25, -25, 0.25, -25, 25, -0.25, -25, -25, -0.25, 25, -25, 0.25, 25, 25, 0.25, -25, 25, -0.25, 25, 25, 0.25, 25)
 
-[node name="EntranceRoom2" type="Node3D" unique_id=1298955981]
+[node name="EntranceRoom" type="Node3D" unique_id=1298955981]
 
 [node name="Walls" type="MeshInstance3D" parent="." unique_id=1011732479]
 mesh = SubResource("ArrayMesh_fij0k")

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/event_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/event_room.tscn
@@ -27,7 +27,7 @@ size = Vector3(50, 0.5, 50)
 [sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_68786"]
 points = PackedVector3Array(-25, -0.25, -25, -25, 0.25, -25, 25, -0.25, -25, -25, -0.25, 25, -25, 0.25, 25, 25, 0.25, -25, 25, -0.25, 25, 25, 0.25, 25)
 
-[node name="EntranceRoom2" type="Node3D" unique_id=1298955981]
+[node name="EventRoom" type="Node3D" unique_id=1298955981]
 
 [node name="Walls" type="MeshInstance3D" parent="." unique_id=2043454782]
 mesh = SubResource("ArrayMesh_68786")

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/event_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/event_room.tscn
@@ -52,32 +52,32 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.59409785, 16.44909)
 [node name="ExitPoint" type="Marker3D" parent="." unique_id=1595695969]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.44763565, -17.54694)
 
-[node name="Entrances" type="Node3D" parent="." unique_id=346511184]
+[node name="Entrances" type="Node3D" parent="." unique_id=228522570]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 16.374111)
 
-[node name="0" type="Marker3D" parent="Entrances" unique_id=707015329]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, 4.9187107)
-
-[node name="1" type="Marker3D" parent="Entrances" unique_id=112222844]
+[node name="0" type="Marker3D" parent="Entrances" unique_id=1990207567]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, 4.9187107)
 
-[node name="2" type="Marker3D" parent="Entrances" unique_id=2120414536]
+[node name="1" type="Marker3D" parent="Entrances" unique_id=23320138]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, 4.9187107)
 
-[node name="3" type="Marker3D" parent="Entrances" unique_id=59496419]
+[node name="2" type="Marker3D" parent="Entrances" unique_id=1114296359]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, 4.9187107)
+
+[node name="3" type="Marker3D" parent="Entrances" unique_id=1305411226]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, 4.9187107)
 
-[node name="Exits" type="Node3D" parent="." unique_id=476148545]
+[node name="Exits" type="Node3D" parent="." unique_id=1701567573]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -13.484043)
 
-[node name="0" type="Marker3D" parent="Exits" unique_id=162859324]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.2970276)
-
-[node name="1" type="Marker3D" parent="Exits" unique_id=1154018645]
+[node name="0" type="Marker3D" parent="Exits" unique_id=1915402223]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, -7.2970276)
 
-[node name="2" type="Marker3D" parent="Exits" unique_id=454553864]
+[node name="1" type="Marker3D" parent="Exits" unique_id=19377419]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, -7.2970276)
 
-[node name="3" type="Marker3D" parent="Exits" unique_id=897839084]
+[node name="2" type="Marker3D" parent="Exits" unique_id=934601416]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.2970276)
+
+[node name="3" type="Marker3D" parent="Exits" unique_id=763744734]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, -7.2970276)

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/exit_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/exit_room.tscn
@@ -26,7 +26,7 @@ size = Vector3(50, 0.5, 50)
 [sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_0drqo"]
 points = PackedVector3Array(-25, -0.25, -25, -25, 0.25, -25, 25, -0.25, -25, -25, -0.25, 25, -25, 0.25, 25, 25, 0.25, -25, 25, -0.25, 25, 25, 0.25, 25)
 
-[node name="EntranceRoom" type="Node3D" unique_id=1298955981]
+[node name="EntranceRoom2" type="Node3D" unique_id=1298955981]
 
 [node name="Walls" type="MeshInstance3D" parent="." unique_id=471473748]
 mesh = SubResource("ArrayMesh_0drqo")
@@ -54,20 +54,15 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.44763565, -17.54694)
 [node name="Entrances" type="Node3D" parent="." unique_id=346511184]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 16.374111)
 
-[node name="0" type="Marker3D" parent="Entrances" unique_id=707015329]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, 4.9187107)
-
-[node name="1" type="Marker3D" parent="Entrances" unique_id=112222844]
+[node name="0" type="Marker3D" parent="Entrances" unique_id=112222844]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, 4.9187107)
 
-[node name="2" type="Marker3D" parent="Entrances" unique_id=2120414536]
+[node name="1" type="Marker3D" parent="Entrances" unique_id=2120414536]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, 4.9187107)
-
-[node name="3" type="Marker3D" parent="Entrances" unique_id=59496419]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, 4.9187107)
 
 [node name="Exits" type="Node3D" parent="." unique_id=476148545]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -13.484043)
+visible = false
 
 [node name="0" type="Marker3D" parent="Exits" unique_id=162859324]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.2970276)

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/exit_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/exit_room.tscn
@@ -26,7 +26,7 @@ size = Vector3(50, 0.5, 50)
 [sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_0drqo"]
 points = PackedVector3Array(-25, -0.25, -25, -25, 0.25, -25, 25, -0.25, -25, -25, -0.25, 25, -25, 0.25, 25, 25, 0.25, -25, 25, -0.25, 25, 25, 0.25, 25)
 
-[node name="EntranceRoom2" type="Node3D" unique_id=1298955981]
+[node name="ExitRoom" type="Node3D" unique_id=1298955981]
 
 [node name="Walls" type="MeshInstance3D" parent="." unique_id=471473748]
 mesh = SubResource("ArrayMesh_0drqo")

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/treasure_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/treasure_room.tscn
@@ -52,32 +52,32 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.59409785, 16.44909)
 [node name="ExitPoint" type="Marker3D" parent="." unique_id=1595695969]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.44763565, -17.54694)
 
-[node name="Entrances" type="Node3D" parent="." unique_id=346511184]
+[node name="Entrances" type="Node3D" parent="." unique_id=1488867071]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 16.374111)
 
-[node name="0" type="Marker3D" parent="Entrances" unique_id=707015329]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, 4.9187107)
-
-[node name="1" type="Marker3D" parent="Entrances" unique_id=112222844]
+[node name="0" type="Marker3D" parent="Entrances" unique_id=107664402]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, 4.9187107)
 
-[node name="2" type="Marker3D" parent="Entrances" unique_id=2120414536]
+[node name="1" type="Marker3D" parent="Entrances" unique_id=434136577]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, 4.9187107)
 
-[node name="3" type="Marker3D" parent="Entrances" unique_id=59496419]
+[node name="2" type="Marker3D" parent="Entrances" unique_id=244678228]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, 4.9187107)
+
+[node name="3" type="Marker3D" parent="Entrances" unique_id=426542712]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, 4.9187107)
 
-[node name="Exits" type="Node3D" parent="." unique_id=476148545]
+[node name="Exits" type="Node3D" parent="." unique_id=81102973]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -13.484043)
 
-[node name="0" type="Marker3D" parent="Exits" unique_id=162859324]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.2970276)
-
-[node name="1" type="Marker3D" parent="Exits" unique_id=1154018645]
+[node name="0" type="Marker3D" parent="Exits" unique_id=603689357]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.2964153, -1.7729723, -7.2970276)
 
-[node name="2" type="Marker3D" parent="Exits" unique_id=454553864]
+[node name="1" type="Marker3D" parent="Exits" unique_id=1108421066]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.3992662, -1.7729723, -7.2970276)
 
-[node name="3" type="Marker3D" parent="Exits" unique_id=897839084]
+[node name="2" type="Marker3D" parent="Exits" unique_id=630323280]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.549403, -1.7729723, -7.2970276)
+
+[node name="3" type="Marker3D" parent="Exits" unique_id=150472824]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.57488, -1.7729723, -7.2970276)

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/treasure_room.tscn
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/treasure_room.tscn
@@ -27,7 +27,7 @@ size = Vector3(50, 0.5, 50)
 [sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_5xbyn"]
 points = PackedVector3Array(-25, -0.25, -25, -25, 0.25, -25, 25, -0.25, -25, -25, -0.25, 25, -25, 0.25, 25, 25, 0.25, -25, 25, -0.25, 25, 25, 0.25, 25)
 
-[node name="EntranceRoom" type="Node3D" unique_id=1298955981]
+[node name="TreasureRoom" type="Node3D" unique_id=1298955981]
 
 [node name="Walls" type="MeshInstance3D" parent="." unique_id=1244738179]
 mesh = SubResource("ArrayMesh_5xbyn")

--- a/flashcard-roguelike/game/entity/enemy_example/EnemyExample.cs
+++ b/flashcard-roguelike/game/entity/enemy_example/EnemyExample.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System.Collections.Generic;
+using System.Linq;
 
 public partial class EnemyExample : CharacterBody3D
 {
@@ -49,8 +50,9 @@ public partial class EnemyExample : CharacterBody3D
 			You would get the room via GetParent().GetParent() assuming the structure is Room -> Enemies -> EnemyExample, 
 			and then get all enemies from the Enemies node. I tested it this way and it worked
 			*/
-
-			BattleManager.Instance.StartBattle(player, new List<EnemyExample> { this }, GetParent<Node3D>());
+			var room = GetParent<Node3D>().GetParent<Node3D>();
+			List<EnemyExample> enemiesInRoom = GetParent<Node3D>().GetChildren().OfType<EnemyExample>().ToList();
+			BattleManager.Instance.StartBattle(player, enemiesInRoom, room);
 		}
 	}
 }

--- a/flashcard-roguelike/game/ui/battle_ui/FlashcardChallenge.cs
+++ b/flashcard-roguelike/game/ui/battle_ui/FlashcardChallenge.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-public partial class FlashcardChallenge : Control
+public partial class FlashcardChallenge : Control, IFlashcardChallenge
 {
 	[Signal]
 	public delegate void OnAnswerSubmittedEventHandler(bool isCorrect);
@@ -20,6 +20,7 @@ public partial class FlashcardChallenge : Control
 
 	private Flashcard _currentCard;
 	private bool _isActive = false;
+	private Action<bool> _onAnswerSubmittedCallback;
 
 	public override void _Ready()
 	{
@@ -37,6 +38,13 @@ public partial class FlashcardChallenge : Control
 
 		// Start hidden
 		Visible = false;
+	}
+
+	public bool Visibility => Visible;
+
+	public void ConnectAnswerSubmitted(Action<bool> callback)
+	{
+		_onAnswerSubmittedCallback = callback;
 	}
 
 	public void ShowChallenge(Flashcard card, string context = "Answer correctly or bad things happen...")
@@ -123,7 +131,11 @@ public partial class FlashcardChallenge : Control
         GetTree().CreateTimer(4.0f).Timeout += () =>
 		{
 			_answerInput.Modulate = Colors.White;
-			HideChallenge(() => EmitSignal(SignalName.OnAnswerSubmitted, isCorrect));
+			HideChallenge(() => 
+			{
+				EmitSignal(SignalName.OnAnswerSubmitted, isCorrect);
+				_onAnswerSubmittedCallback?.Invoke(isCorrect);
+			});
 		};
 	}
 

--- a/flashcard-roguelike/game/ui/battle_ui/FlashcardChallengeManager.cs
+++ b/flashcard-roguelike/game/ui/battle_ui/FlashcardChallengeManager.cs
@@ -1,0 +1,106 @@
+using Godot;
+using System;
+
+// Manages all flashcard challenge types and selects which type to show based on difficulty
+// Handles visibility and interaction with all three challenge implementations
+public class FlashcardChallengeManager
+{
+	private FlashcardChallenge _textChallenge;
+	private FlashcardChallengeTrueOrFalse _trueOrFalseChallenge;
+	private FlashcardChallengeMultipleChoice _multipleChoiceChallenge;
+
+	private IFlashcardChallenge _currentChallenge;
+	private Action<bool> _onAnswerSubmittedCallback;
+
+	public void Initialize(
+		FlashcardChallenge textChallenge,
+		FlashcardChallengeTrueOrFalse trueOrFalseChallenge,
+		FlashcardChallengeMultipleChoice multipleChoiceChallenge)
+	{
+		_textChallenge = textChallenge;
+		_trueOrFalseChallenge = trueOrFalseChallenge;
+		_multipleChoiceChallenge = multipleChoiceChallenge;
+
+		// Connect answer submitted callbacks from all challenges
+		_textChallenge.ConnectAnswerSubmitted(OnAnswerSubmitted);
+		_trueOrFalseChallenge.ConnectAnswerSubmitted(OnAnswerSubmitted);
+		_multipleChoiceChallenge.ConnectAnswerSubmitted(OnAnswerSubmitted);
+	}
+
+	public void SetAnswerSubmittedCallback(Action<bool> callback)
+	{
+		_onAnswerSubmittedCallback = callback;
+	}
+
+	// Show a challenge with difficulty parameter (default 0 = T/F, 1 = MC, 2 = Text)
+	public void ShowChallenge(Flashcard card, string context = "Answer correctly or bad things happen...", float difficulty = 0)
+	{
+		if (card == null) return;
+
+		// Select challenge type based on difficulty
+		IFlashcardChallenge challengeToShow = SelectChallengeByDifficulty(difficulty);
+
+		// Hide the current challenge if one is active
+		if (_currentChallenge != null && _currentChallenge.Visibility)
+		{
+			_currentChallenge.HideChallenge();
+		}
+
+		// Show the selected challenge
+		_currentChallenge = challengeToShow;
+		_currentChallenge.ShowChallenge(card, context);
+	}
+
+	// Hide the current active challenge
+	public void HideChallenge(Action onComplete = null)
+	{
+		if (_currentChallenge != null)
+		{
+			_currentChallenge.HideChallenge(onComplete);
+		}
+		else
+		{
+			onComplete?.Invoke();
+		}
+	}
+
+	// Load a random flashcard (delegates to current challenge)
+	public Flashcard LoadRandomCard()
+	{
+		if (_currentChallenge == null) return _textChallenge.LoadRandomCard();
+		return _currentChallenge.LoadRandomCard();
+	}
+
+	private IFlashcardChallenge SelectChallengeByDifficulty(float difficulty)
+	{
+        Random random = new Random();
+        float roll = (float)random.NextDouble();
+
+        // Normalize difficulty (1–5 -> 0–1)
+        float d = (difficulty - 1) / 4f; // Assuming difficulty ranges from 1 to 5
+
+        float trueFalseChance = 0.7f - (0.6f * d); // Decreases from 70% to 10%
+        float multipleChoiceChance = 0.2f + (0.2f * d); // Increases from 20% to 40%
+        float textChance = 0.1f + (0.4f * d); // Increases from 10% to 50%
+
+        GD.Print($"Difficulty: {difficulty}, Roll: {roll}, T/F Chance: {trueFalseChance}, MC Chance: {multipleChoiceChance}, Text Chance: {textChance}");
+
+        if (roll < trueFalseChance)
+        {
+            return _trueOrFalseChallenge;
+        }
+        else if (roll < trueFalseChance + multipleChoiceChance)
+        {
+            return _multipleChoiceChallenge;
+        }
+        else
+        {
+            return _textChallenge;
+        }
+	}
+
+	private void OnAnswerSubmitted(bool isCorrect)
+	{
+		_onAnswerSubmittedCallback?.Invoke(isCorrect);
+	}
+}

--- a/flashcard-roguelike/game/ui/battle_ui/FlashcardChallengeMultipleChoice.cs
+++ b/flashcard-roguelike/game/ui/battle_ui/FlashcardChallengeMultipleChoice.cs
@@ -1,0 +1,247 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public partial class FlashcardChallengeMultipleChoice : Control, IFlashcardChallenge
+{
+	private Panel _challengePanel;
+	private Label _questionLabel;
+	private Button _optionAButton;
+	private Button _optionBButton;
+	private Button _optionCButton;
+	private Button _optionDButton;
+	private Label _contextLabel;
+
+	private Flashcard _currentCard;
+	private Button[] _optionButtons;
+	private string _correctAnswer;
+	private bool _isActive = false;
+	private float _showDuration = 0.3f;
+	private float _hideDuration = 0.3f;
+
+	private Action<bool> _onAnswerSubmitted;
+
+	public bool Visibility => Visible;
+
+	public override void _Ready()
+	{
+		// Get UI elements
+		_challengePanel = GetNode<Panel>("ChallengePanel");
+		_questionLabel = GetNode<Label>("ChallengePanel/MarginContainer/VBoxContainer/QuestionLabel");
+		_contextLabel = GetNode<Label>("ChallengePanel/MarginContainer/VBoxContainer/ContextLabel");
+		_optionAButton = GetNode<Button>("ChallengePanel/MarginContainer/VBoxContainer/OptionsContainer/OptionAButton");
+		_optionBButton = GetNode<Button>("ChallengePanel/MarginContainer/VBoxContainer/OptionsContainer/OptionBButton");
+		_optionCButton = GetNode<Button>("ChallengePanel/MarginContainer/VBoxContainer/OptionsContainer/OptionCButton");
+		_optionDButton = GetNode<Button>("ChallengePanel/MarginContainer/VBoxContainer/OptionsContainer/OptionDButton");
+
+		_optionButtons = new Button[] { _optionAButton, _optionBButton, _optionCButton, _optionDButton };
+
+		// Connect signals
+		_optionAButton.Pressed += () => OnOptionSelected(_optionAButton.Text);
+		_optionBButton.Pressed += () => OnOptionSelected(_optionBButton.Text);
+		_optionCButton.Pressed += () => OnOptionSelected(_optionCButton.Text);
+		_optionDButton.Pressed += () => OnOptionSelected(_optionDButton.Text);
+
+		// Start hidden
+		Visible = false;
+	}
+
+	public void ConnectAnswerSubmitted(Action<bool> callback)
+	{
+		_onAnswerSubmitted = callback;
+	}
+
+	public void ShowChallenge(Flashcard card, string context = "Answer correctly or bad things happen...")
+	{
+		if (_isActive || card == null) return;
+
+		_currentCard = card;
+		_correctAnswer = card.Answer;
+		_isActive = true;
+
+		// Get three incorrect answers from other cards
+		List<string> allOptions = GetWrongAnswers(card, 3);
+
+		// Create a list of all options (1 correct + 3 wrong)  
+        allOptions.Add(_correctAnswer);
+
+		// Shuffle the options
+		ShuffleList(allOptions);
+
+		// Assign options to buttons
+		for (int i = 0; i < _optionButtons.Length; i++)
+		{
+			_optionButtons[i].Text = allOptions[i];
+			_optionButtons[i].Disabled = false;
+		}
+
+		_questionLabel.Text = card.Question;
+		_contextLabel.Text = context;
+
+		// Show with fade-in animation
+		Visible = true;
+		Tween tween = CreateTween();
+		tween.TweenProperty(_challengePanel, "modulate:a", 1.0f, _showDuration)
+			 .SetTrans(Tween.TransitionType.Quad)
+			 .SetEase(Tween.EaseType.Out);
+
+		// Focus the first button
+		CallDeferred("FocusFirstButton");
+	}
+
+	private void FocusFirstButton()
+	{
+		_optionAButton.GrabFocus();
+	}
+
+	public void HideChallenge(Action onComplete = null)
+	{
+		if (!_isActive) return;
+
+		_isActive = false;
+		foreach (var button in _optionButtons)
+		{
+			button.Disabled = true;
+		}
+
+		// Hide with fade-out animation
+		Tween tween = CreateTween();
+		tween.TweenProperty(_challengePanel, "modulate:a", 0.0f, _hideDuration)
+			 .SetTrans(Tween.TransitionType.Quad)
+			 .SetEase(Tween.EaseType.In);
+
+		tween.TweenCallback(Callable.From(() =>
+		{
+			Visible = false;
+			_currentCard = null;
+			onComplete?.Invoke();
+		}));
+	}
+
+	private void OnOptionSelected(string selectedAnswer)
+	{
+		if (!_isActive || _currentCard == null) return;
+
+		// Disable all buttons
+		foreach (var button in _optionButtons)
+		{
+			button.Disabled = true;
+		}
+
+		// Check if the answer is correct
+		bool isCorrect = selectedAnswer.Equals(_correctAnswer, StringComparison.OrdinalIgnoreCase);
+
+		// Visual feedback - highlight all buttons
+		Color correctColor = new Color(0.5f, 1.0f, 0.5f); // Green for correct
+		Color wrongColor = new Color(1.0f, 0.5f, 0.5f);   // Red for wrong
+		Color neutralColor = Colors.White;
+
+		foreach (var button in _optionButtons)
+		{
+			if (button.Text.Equals(_correctAnswer, StringComparison.OrdinalIgnoreCase))
+			{
+				button.Modulate = correctColor; // Highlight the correct answer
+			}
+			else if (!isCorrect && button.Text.Equals(selectedAnswer, StringComparison.OrdinalIgnoreCase))
+			{
+				button.Modulate = wrongColor; // Highlight the selected wrong answer
+			}
+			else 
+			{
+				button.Modulate = neutralColor; // Keep unselected wrong answers neutral
+			}
+		}
+
+		if (!isCorrect)
+		{
+			_contextLabel.Text = $"Incorrect! The correct answer is: {_correctAnswer}";
+		}
+
+		// Wait a moment then hide and emit result
+		GetTree().CreateTimer(4.0f).Timeout += () =>
+		{
+			foreach (var button in _optionButtons)
+			{
+				button.Modulate = Colors.White;
+			}
+			HideChallenge(() => _onAnswerSubmitted?.Invoke(isCorrect));
+		};
+	}
+
+	public Flashcard LoadRandomCard()
+	{
+		List<FlashcardSet> sets = FlashcardManager.Instance?.ActiveFlashCardLists;
+
+		if (sets == null || sets.Count == 0)
+		{
+			GD.PrintErr("FlashcardChallengeMultipleChoice: No flashcard sets available.");
+			return null;
+		}
+
+        // Get a random card
+		List<Flashcard> allCards = new List<Flashcard>();
+		foreach (var set in sets)
+		{
+			if (set.Cards != null)
+				allCards.AddRange(set.Cards);
+		}
+
+		if (allCards.Count == 0)
+		{
+			GD.PrintErr("FlashcardChallengeMultipleChoice: No flashcards available in sets.");
+			return null;
+		}
+
+		Random random = new Random();
+		return allCards[random.Next(allCards.Count)];
+	}
+
+	private List<string> GetWrongAnswers(Flashcard excludeCard, int count)
+	{
+		List<FlashcardSet> sets = FlashcardManager.Instance.ActiveFlashCardLists;
+		List<string> wrongAnswers = new List<string>();
+
+		if (sets == null || sets.Count == 0) return wrongAnswers;
+
+        // Get all cards excluding the current one
+		List<Flashcard> otherCards = new List<Flashcard>();
+		foreach (var set in sets)
+		{
+            foreach (var card in set.Cards)
+            {
+                if (card == excludeCard) continue; // Skip the card we want to exclude
+                otherCards.Add(card);
+            }
+		}
+
+		Random random = new Random();
+
+		// Get up to 'count' wrong answers
+		for (int i = 0; i < count && otherCards.Count > 0; i++)
+		{
+			int randomIndex = random.Next(otherCards.Count);
+			wrongAnswers.Add(otherCards[randomIndex].Answer);
+			otherCards.RemoveAt(randomIndex);
+		}
+
+		// If we don't have enough wrong answers, add filler (shouldn't happen with real data)
+		while (wrongAnswers.Count < count && otherCards.Count > 0)
+		{
+			wrongAnswers.Add("No other cards available");
+		}
+
+		return wrongAnswers;
+	}
+
+	private void ShuffleList(List<string> list)
+	{
+        // Basic shuffling
+		Random random = new Random();
+		for (int i = list.Count - 1; i > 0; i--)
+		{
+			int randomIndex = random.Next(i + 1);
+			(list[i], list[randomIndex]) = (list[randomIndex], list[i]);
+		}
+	}
+}

--- a/flashcard-roguelike/game/ui/battle_ui/FlashcardChallengeTrueOrFalse.cs
+++ b/flashcard-roguelike/game/ui/battle_ui/FlashcardChallengeTrueOrFalse.cs
@@ -1,0 +1,201 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+
+public partial class FlashcardChallengeTrueOrFalse : Control, IFlashcardChallenge
+{
+	private Panel _challengePanel;
+	private Label _questionLabel;
+    private Label _answerLabel;
+	private Button _trueButton;
+	private Button _falseButton;
+	private Label _contextLabel;
+
+	private Flashcard _currentCard;
+	private Flashcard _incorrectCard;
+    private bool _shownStatementIsCorrect;
+	private bool _isActive = false;
+	private float _showDuration = 0.3f;
+	private float _hideDuration = 0.3f;
+
+	private Action<bool> _onAnswerSubmitted;
+
+    public bool Visibility => Visible;
+
+	public override void _Ready()
+	{
+		// Get UI elements
+		_challengePanel = GetNode<Panel>("ChallengePanel");
+		_questionLabel = GetNode<Label>("ChallengePanel/MarginContainer/VBoxContainer/QuestionLabel");
+        _answerLabel = GetNode<Label>("ChallengePanel/MarginContainer/VBoxContainer/AnswerLabel");
+		_contextLabel = GetNode<Label>("ChallengePanel/MarginContainer/VBoxContainer/ContextLabel");
+		_trueButton = GetNode<Button>("ChallengePanel/MarginContainer/VBoxContainer/ButtonContainer/TrueButton");
+		_falseButton = GetNode<Button>("ChallengePanel/MarginContainer/VBoxContainer/ButtonContainer/FalseButton");
+
+		// Connect signals
+		_trueButton.Pressed += () => OnAnswerSelected(true);
+		_falseButton.Pressed += () => OnAnswerSelected(false);
+
+		// Start hidden
+		Visible = false;
+	}
+
+	public void ConnectAnswerSubmitted(Action<bool> callback)
+	{
+		_onAnswerSubmitted = callback;
+	}
+
+	public void ShowChallenge(Flashcard card, string context = "Answer correctly or bad things happen...")
+	{
+		if (_isActive || card == null) return;
+
+		_currentCard = card;
+		_isActive = true;
+
+		// Get an incorrect card from another flashcard in the set
+		_incorrectCard = GetRandomDifferentCard(card);
+
+        // Set question
+        _questionLabel.Text = $"Question:\n{card.Question}";
+
+		// Randomly decide if the statement shown is True or False, 50/50
+		bool showTrue = new Random().Next(2) == 0;
+        _shownStatementIsCorrect = showTrue; // Track if the shown statement is correct for answer evaluation
+
+		if (showTrue)
+		{
+			_answerLabel.Text = $"Answer:\n{_currentCard.Answer}";
+		}
+		else
+		{
+			_answerLabel.Text = $"Answer:\n{_incorrectCard.Answer}";
+		}
+
+		_contextLabel.Text = context;
+		_trueButton.Disabled = false;
+		_falseButton.Disabled = false;
+
+		// Show with fade-in animation
+		Visible = true;
+		Tween tween = CreateTween();
+		tween.TweenProperty(_challengePanel, "modulate:a", 1.0f, _showDuration)
+			 .SetTrans(Tween.TransitionType.Quad)
+			 .SetEase(Tween.EaseType.Out);
+	}
+
+	public void HideChallenge(Action onComplete = null)
+	{
+		if (!_isActive) return;
+
+		_isActive = false;
+		_trueButton.Disabled = true;
+		_falseButton.Disabled = true;
+
+		// Hide with fade-out animation
+		Tween tween = CreateTween();
+		tween.TweenProperty(_challengePanel, "modulate:a", 0.0f, _hideDuration)
+			 .SetTrans(Tween.TransitionType.Quad)
+			 .SetEase(Tween.EaseType.In);
+
+		tween.TweenCallback(Callable.From(() =>
+		{
+			Visible = false;
+			_currentCard = null;
+			_incorrectCard = null;
+			onComplete?.Invoke();
+		}));
+	}
+
+	private void OnAnswerSelected(bool selectedTrue)
+	{
+		if (!_isActive || _currentCard == null) return;
+
+		// Disable buttons
+		_trueButton.Disabled = true;
+		_falseButton.Disabled = true;
+
+		// Determine if answer is correct
+		// The statement shown was either the correct answer or an incorrect one
+		bool isCorrect = DetermineIfCorrect(selectedTrue);
+
+		// Visual feedback
+		if (isCorrect)
+		{
+			_trueButton.Modulate = new Color(0.5f, 1.0f, 0.5f);
+			_falseButton.Modulate = new Color(0.5f, 1.0f, 0.5f);
+		}
+		else
+		{
+			_trueButton.Modulate = new Color(1.0f, 0.5f, 0.5f);
+			_falseButton.Modulate = new Color(1.0f, 0.5f, 0.5f);
+			_contextLabel.Text = "Incorrect!";
+		}
+
+		// Wait a moment then hide and emit result
+		GetTree().CreateTimer(4.0f).Timeout += () =>
+		{
+			_trueButton.Modulate = Colors.White;
+			_falseButton.Modulate = Colors.White;
+			HideChallenge(() => _onAnswerSubmitted?.Invoke(isCorrect));
+		};
+	}
+
+	private bool DetermineIfCorrect(bool selectedTrue)
+	{
+        return _shownStatementIsCorrect == selectedTrue;
+	}
+
+	public Flashcard LoadRandomCard()
+	{
+		List<FlashcardSet> sets = FlashcardManager.Instance.ActiveFlashCardLists;
+
+		if (sets == null || sets.Count == 0)
+		{
+			GD.PrintErr("FlashcardChallengeTrueOrFalse: No flashcard sets available.");
+			return null;
+		}
+
+        // Get a random card from all active sets
+		List<Flashcard> allCards = new List<Flashcard>();
+		foreach (var set in sets)
+		{
+			if (set.Cards != null)
+				allCards.AddRange(set.Cards);
+		}
+
+		if (allCards.Count == 0)
+		{
+			GD.PrintErr("FlashcardChallengeTrueOrFalse: No flashcards available in sets.");
+			return null;
+		}
+
+		Random random = new Random();
+		return allCards[random.Next(allCards.Count)];
+	}
+
+	private Flashcard GetRandomDifferentCard(Flashcard excludeCard)
+	{
+		List<FlashcardSet> sets = FlashcardManager.Instance.ActiveFlashCardLists;
+
+		if (sets == null || sets.Count == 0) return excludeCard;
+
+        // Get a list of all other cards
+		List<Flashcard> otherCards = new List<Flashcard>();
+		foreach (var set in sets)
+		{
+			if (set.Cards != null)
+			
+            foreach (var card in set.Cards)
+            {
+                if (card == excludeCard) continue; // Skip the card we want to exclude
+                otherCards.Add(card);
+            } 
+		}
+
+		if (otherCards.Count == 0) return excludeCard;
+
+        // Return a random other card
+		Random random = new Random();
+		return otherCards[random.Next(otherCards.Count)];
+	}
+}

--- a/flashcard-roguelike/game/ui/battle_ui/FlashcardChallengeTrueOrFalse.cs
+++ b/flashcard-roguelike/game/ui/battle_ui/FlashcardChallengeTrueOrFalse.cs
@@ -128,7 +128,8 @@ public partial class FlashcardChallengeTrueOrFalse : Control, IFlashcardChalleng
 		{
 			_trueButton.Modulate = new Color(1.0f, 0.5f, 0.5f);
 			_falseButton.Modulate = new Color(1.0f, 0.5f, 0.5f);
-			_contextLabel.Text = "Incorrect!";
+			_contextLabel.Text = "Incorrect! The correct answer for:";
+            _answerLabel.Text = $"Answer:\n{_currentCard.Answer}";
 		}
 
 		// Wait a moment then hide and emit result

--- a/flashcard-roguelike/game/ui/battle_ui/IFlashcardChallenge.cs
+++ b/flashcard-roguelike/game/ui/battle_ui/IFlashcardChallenge.cs
@@ -1,0 +1,21 @@
+using Godot;
+using System;
+
+// Interface for all flashcard challenge types to ensure consistency
+public interface IFlashcardChallenge
+{
+    // Signal when answer is submitted with result (true/false for correct/incorrect)
+    void ConnectAnswerSubmitted(Action<bool> callback);
+    
+    // Show the challenge with a flashcard and optional context
+    void ShowChallenge(Flashcard card, string context = "Answer correctly or bad things happen...");
+    
+    // Hide the challenge with optional completion callback
+    void HideChallenge(Action onComplete = null);
+    
+    // Load a random flashcard from available sets
+    Flashcard LoadRandomCard();
+    
+    // Get the visibility state
+    bool Visibility { get; }
+}

--- a/flashcard-roguelike/game/ui/battle_ui/flashcard_challenge_multiple_choice.tscn
+++ b/flashcard-roguelike/game/ui/battle_ui/flashcard_challenge_multiple_choice.tscn
@@ -1,0 +1,109 @@
+[gd_scene format=3 uid="uid://bd8e25jian5kb"]
+
+[ext_resource type="Script" path="res://game/ui/battle_ui/FlashcardChallengeMultipleChoice.cs" id="1_multiple_choice"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dark_panel"]
+bg_color = Color(0.18, 0.18, 0.18, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.45, 0.45, 0.45, 1)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+
+[node name="FlashcardChallengeMultipleChoice" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("1_multiple_choice")
+
+[node name="ChallengePanel" type="Panel" parent="."]
+self_modulate = Color(0.3, 0.3, 0.3, 1)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -350.0
+offset_top = -250.0
+offset_right = 350.0
+offset_bottom = 250.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_dark_panel")
+
+[node name="MarginContainer" type="MarginContainer" parent="ChallengePanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ChallengePanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="TitleLabel" type="Label" parent="ChallengePanel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Multiple Choice"
+horizontal_alignment = 1
+
+[node name="ContextLabel" type="Label" parent="ChallengePanel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Answer correctly to continue"
+horizontal_alignment = 1
+
+[node name="Separator1" type="HSeparator" parent="ChallengePanel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="QuestionLabel" type="Label" parent="ChallengePanel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 2
+theme_override_font_sizes/font_size = 18
+text = "Question will appear here"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
+
+[node name="Separator2" type="HSeparator" parent="ChallengePanel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="OptionsContainer" type="VBoxContainer" parent="ChallengePanel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 12
+
+[node name="OptionAButton" type="Button" parent="ChallengePanel/MarginContainer/VBoxContainer/OptionsContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+text = "Option A"
+
+[node name="OptionBButton" type="Button" parent="ChallengePanel/MarginContainer/VBoxContainer/OptionsContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+text = "Option B"
+
+[node name="OptionCButton" type="Button" parent="ChallengePanel/MarginContainer/VBoxContainer/OptionsContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+text = "Option C"
+
+[node name="OptionDButton" type="Button" parent="ChallengePanel/MarginContainer/VBoxContainer/OptionsContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+text = "Option D"

--- a/flashcard-roguelike/game/ui/battle_ui/flashcard_challenge_true_false.tscn
+++ b/flashcard-roguelike/game/ui/battle_ui/flashcard_challenge_true_false.tscn
@@ -1,0 +1,109 @@
+[gd_scene format=3 uid="uid://cnitj3uodab4s"]
+
+[ext_resource type="Script" uid="uid://dpfa5elccyad0" path="res://game/ui/battle_ui/FlashcardChallengeTrueOrFalse.cs" id="1_true_false"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dark_panel"]
+bg_color = Color(0.18, 0.18, 0.18, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.45, 0.45, 0.45, 1)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+
+[node name="FlashcardChallengeTrueOrFalse" type="Control" unique_id=228099819]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("1_true_false")
+
+[node name="ChallengePanel" type="Panel" parent="." unique_id=1086843691]
+self_modulate = Color(0.3, 0.3, 0.3, 1)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -300.0
+offset_top = -200.0
+offset_right = 300.0
+offset_bottom = 200.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_dark_panel")
+
+[node name="MarginContainer" type="MarginContainer" parent="ChallengePanel" unique_id=1987394491]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ChallengePanel/MarginContainer" unique_id=428053506]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="TitleLabel" type="Label" parent="ChallengePanel/MarginContainer/VBoxContainer" unique_id=391179865]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "True or False?"
+horizontal_alignment = 1
+
+[node name="ContextLabel" type="Label" parent="ChallengePanel/MarginContainer/VBoxContainer" unique_id=761066353]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Answer correctly to continue"
+horizontal_alignment = 1
+
+[node name="Separator1" type="HSeparator" parent="ChallengePanel/MarginContainer/VBoxContainer" unique_id=1125238984]
+layout_mode = 2
+
+[node name="QuestionLabel" type="Label" parent="ChallengePanel/MarginContainer/VBoxContainer" unique_id=1273361382]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_font_sizes/font_size = 20
+text = "Question will appear here"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
+
+[node name="AnswerLabel" type="Label" parent="ChallengePanel/MarginContainer/VBoxContainer" unique_id=81422707]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_font_sizes/font_size = 20
+text = "Answer will appear here"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
+
+[node name="Separator2" type="HSeparator" parent="ChallengePanel/MarginContainer/VBoxContainer" unique_id=1368987894]
+layout_mode = 2
+
+[node name="ButtonContainer" type="HBoxContainer" parent="ChallengePanel/MarginContainer/VBoxContainer" unique_id=457254837]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="TrueButton" type="Button" parent="ChallengePanel/MarginContainer/VBoxContainer/ButtonContainer" unique_id=978703684]
+custom_minimum_size = Vector2(120, 60)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "TRUE"
+
+[node name="FalseButton" type="Button" parent="ChallengePanel/MarginContainer/VBoxContainer/ButtonContainer" unique_id=46954838]
+custom_minimum_size = Vector2(120, 60)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "FALSE"

--- a/flashcard-roguelike/shared/game_difficulty_manager/GameDifficultyManager.cs
+++ b/flashcard-roguelike/shared/game_difficulty_manager/GameDifficultyManager.cs
@@ -3,10 +3,14 @@ using System;
 
 public partial class GameDifficultyManager : Node
 {
+	// Singleton for access since it is autoloaded
+	public static GameDifficultyManager Instance { get; private set; }
+
 	private float _currentDifficultyScore = 0.0F;
 	private float _baselineDifficultyScore = 1.0F;
 	private float _difficultyScoreIncrease = 0.50F;  // 0.50 for testing purposes we can adjust values later on
 	private float _difficultyScoreDecrease = 0.50F; 
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
@@ -16,6 +20,8 @@ public partial class GameDifficultyManager : Node
 		// Add one more event when player reaches new floor update _baselineDiffcultyScore, floors wont be implemented this sprint
 		// Most likely will just increase by flat 1.0 value every floor
 		_currentDifficultyScore = _baselineDifficultyScore;
+
+		Instance = this;
 	}
 	
 	public int getEnemyCount(){
@@ -25,6 +31,9 @@ public partial class GameDifficultyManager : Node
 		if(chanceResult < enemyChance){ // chance of an additional enemy increases the higher your difficulty score increases
 			enemyCount += 1;
 		}
+
+		enemyCount = Math.Min(enemyCount, 3); // Cap enemy count at 3 for now
+		
 		return enemyCount;
 	}
 	


### PR DESCRIPTION
feat: two new types of flashcards: MQ, T/F
feat: difficulty determines enemy count in rooms (max 3), and flashcard type 
feat: more restrictions and minimum room enforcement during generation
feat: flashcard challenge manager and interface to handle what to present and enforce consistency
fix: room connections have been re-arranged, combat rooms have an enemy node and enemy placement markers
fix: enemies are properly collected for combat
fix: made game difficulty manager a singleton with Instance to easily access it
fix: commented what the dungeon gen code does

desc: not too intense of a PR this time. the dungeon generation should be more restrictive now and enforce minimum room counts. I commented out a portion that added extra connections to reduce confusion for now. some minor adjustments to marker placement in rooms was made. difficulty determines the enemy count with a max of 3 per combat room. there are also 2 new types of flashcards now: MQ and T/F. these are selected via the flashcard challenge manager and affected by difficulty. for now at base difficulty: 70% chance for T/F, 20% for MQ, 10% for text input. most confusing things are commented so take a look, feel free to ask questions if something is unclear, thanks.