### PR TITLE
feat: game victory ui screen with mapping to new game, main menu, and exit

### DIFF
--- a/flashcard-roguelike/FlashcardRoguelike.csproj
+++ b/flashcard-roguelike/FlashcardRoguelike.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.6.0">
+<Project Sdk="Godot.NET.Sdk/4.6.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>

--- a/flashcard-roguelike/game/ui/victory/VictoryMenu.cs
+++ b/flashcard-roguelike/game/ui/victory/VictoryMenu.cs
@@ -1,0 +1,80 @@
+using Godot;
+using System;
+
+/// <summary>
+/// Victory screen displayed when the player completes the dungeon.
+/// Allows the player to start a new run or return to the main menu.
+/// </summary>
+public partial class VictoryMenu : CanvasLayer
+{
+	[Export]
+	public PackedScene MainMenuScene { get; set; }
+	
+	private Control _panel;
+	private Label _titleLabel;
+	private Label _messageLabel;
+	
+	public override void _Ready()
+	{
+		_panel = GetNodeOrNull<Control>("Panel");
+		_titleLabel = GetNodeOrNull<Label>("Panel/VBoxContainer/TitleLabel");
+		_messageLabel = GetNodeOrNull<Label>("Panel/VBoxContainer/MessageLabel");
+		
+		// Ensure mouse is visible when victory shows
+		ProcessMode = ProcessModeEnum.Always;
+		
+		// If running this scene directly (for preview), show immediately
+		if (GetTree().CurrentScene == this)
+		{
+			ShowVictory();
+		}
+		else
+		{
+			// Start hidden when loaded as part of another scene
+			Visible = false;
+		}
+	}
+	
+	/// <summary>
+	/// Shows the victory screen with an optional custom message.
+	/// </summary>
+	public void ShowVictory(string message = "Congratulations! You conquered the dungeon!")
+	{
+		if (_messageLabel != null)
+		{
+			_messageLabel.Text = message;
+		}
+		
+		Visible = true;
+		Input.MouseMode = Input.MouseModeEnum.Visible;
+		GetTree().Paused = true;
+	}
+	
+	public void _on_new_run_pressed()
+	{
+		GD.Print("Starting new run...");
+		GetTree().Paused = false;
+		GetTree().ChangeSceneToFile("res://game/entity/dungeon_generator/dungeon_generator.tscn");
+	}
+	
+	public void _on_main_menu_pressed()
+	{
+		GD.Print("Returning to main menu...");
+		GetTree().Paused = false;
+		
+		if (MainMenuScene != null)
+		{
+			GetTree().ChangeSceneToPacked(MainMenuScene);
+		}
+		else
+		{
+			GetTree().ChangeSceneToFile("res://game/ui/main_menu/main_menu.tscn");
+		}
+	}
+	
+	public void _on_quit_pressed()
+	{
+		GD.Print("Quitting game...");
+		GetTree().Quit();
+	}
+}

--- a/flashcard-roguelike/game/ui/victory/victory_menu.tscn
+++ b/flashcard-roguelike/game/ui/victory/victory_menu.tscn
@@ -1,0 +1,80 @@
+[gd_scene load_steps=2 format=3 uid="uid://victory_menu"]
+
+[ext_resource type="Script" path="res://game/ui/victory/VictoryMenu.cs" id="1_script"]
+
+[node name="VictoryMenu" type="CanvasLayer"]
+process_mode = 3
+script = ExtResource("1_script")
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ColorRect" type="ColorRect" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.05, 0.1, 0.05, 0.85)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -200.0
+offset_top = -150.0
+offset_right = 200.0
+offset_bottom = 150.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 20
+
+[node name="TitleLabel" type="Label" parent="Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 48
+theme_override_colors/font_color = Color(1, 0.85, 0.2, 1)
+text = "VICTORY!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="MessageLabel" type="Label" parent="Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+text = "Congratulations! You conquered the dungeon!"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
+
+[node name="Spacer" type="Control" parent="Panel/VBoxContainer"]
+custom_minimum_size = Vector2(0, 20)
+layout_mode = 2
+
+[node name="NewRunButton" type="Button" parent="Panel/VBoxContainer"]
+custom_minimum_size = Vector2(200, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+text = "New Run"
+
+[node name="MainMenuButton" type="Button" parent="Panel/VBoxContainer"]
+custom_minimum_size = Vector2(200, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Main Menu"
+
+[node name="QuitButton" type="Button" parent="Panel/VBoxContainer"]
+custom_minimum_size = Vector2(200, 50)
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Quit Game"
+
+[connection signal="pressed" from="Panel/VBoxContainer/NewRunButton" to="." method="_on_new_run_pressed"]
+[connection signal="pressed" from="Panel/VBoxContainer/MainMenuButton" to="." method="_on_main_menu_pressed"]
+[connection signal="pressed" from="Panel/VBoxContainer/QuitButton" to="." method="_on_quit_pressed"]


### PR DESCRIPTION
This pull request introduces a new victory screen feature for the game, providing a polished user interface when the player completes the dungeon. The changes include a new C# script for managing the victory menu, a corresponding scene file defining its UI layout, and an update to the project SDK version.

Victory screen implementation:

* Added `VictoryMenu.cs`, a new C# script that manages the victory screen, including showing a congratulatory message, handling user actions for starting a new run, returning to the main menu, and quitting the game.
* Added `victory_menu.tscn`, a new scene file that defines the UI layout for the victory screen, including labels, buttons, and signal connections for user interaction.

Project configuration update:

* Updated `FlashcardRoguelike.csproj` to use the Godot.NET SDK version 4.6.1, ensuring compatibility and access to the latest features.… exit