### PR TITLE
feat: add session stats overlay

### DIFF
--- a/flashcard-roguelike/game/entity/dungeon_generator/DungeonGenerator.cs
+++ b/flashcard-roguelike/game/entity/dungeon_generator/DungeonGenerator.cs
@@ -24,6 +24,7 @@ public partial class DungeonGenerator : Node3D
 	
 	public override void _Ready()
 	{
+		TaloTelemetry.ResetSessionStats();
 		AudioManager.Instance?.PlayDungeonMusic();
 		// Initialize random number generator with seed
 		if (UseRandomSeed)

--- a/flashcard-roguelike/game/ui/game_over/GameOverMenu.cs
+++ b/flashcard-roguelike/game/ui/game_over/GameOverMenu.cs
@@ -1,95 +1,269 @@
 using Godot;
-using System;
-using System.Collections;
+using System.Collections.Generic;
 
 /// <summary>
 /// Game over screen displayed when the player dies.
-/// Allows the player to restart or return to the main menu.
+/// Shows only the tracked Talo session stats and returns to the main menu on input.
 /// </summary>
 public partial class GameOverMenu : CanvasLayer
 {
 	[Export]
 	public PackedScene MainMenuScene { get; set; }
-	
-	[Export]
-	public PackedScene GameScene { get; set; }
-	
-	private Control _panel;
-	private Label _titleLabel;
+
+	public bool PendingShow { get; set; }
+	public string PendingMessage { get; set; } = "Run summary";
+	public bool PendingPlayAudio { get; set; }
+
+	private const string MarkerFontPath = "res://assets/fonts/DryWhiteboardMarker-Regular.ttf";
+
+	private FontFile _markerFont;
 	private Label _messageLabel;
-	
+	private Label _statsHeaderLabel;
+	private VBoxContainer _statsListContainer;
+	private bool _advanceRequested;
+
 	public override void _Ready()
 	{
-		_panel = GetNodeOrNull<Control>("Panel");
-		_titleLabel = GetNodeOrNull<Label>("Panel/VBoxContainer/TitleLabel");
-		_messageLabel = GetNodeOrNull<Label>("Panel/VBoxContainer/MessageLabel");
+		_markerFont = GD.Load<FontFile>(MarkerFontPath);
+		_messageLabel = GetNodeOrNull<Label>("CenterContainer/MainPanel/MarginContainer/MainVBox/MessageLabel");
+		_statsHeaderLabel = GetNodeOrNull<Label>("CenterContainer/MainPanel/MarginContainer/MainVBox/StatsHeaderLabel");
+		_statsListContainer = GetNodeOrNull<VBoxContainer>("CenterContainer/MainPanel/MarginContainer/MainVBox/StatsListContainer");
 
-		Button _restartButton = GetNodeOrNull<Button>("Panel/VBoxContainer/RestartButton");
-		Button _mainMenuButton = GetNodeOrNull<Button>("Panel/VBoxContainer/MainMenuButton");
-		Button _quitButton = GetNodeOrNull<Button>("Panel/VBoxContainer/QuitButton");
+		ApplyMarkerFontRecursive(this);
 
-		AudioManager.Instance?.RegisterButton(_restartButton);
-		AudioManager.Instance?.RegisterButton(_mainMenuButton);
-		AudioManager.Instance?.RegisterButton(_quitButton);
-		
-		// Start hidden
 		Visible = false;
-		
-		// Ensure mouse is visible when game over shows
 		ProcessMode = ProcessModeEnum.Always;
+
+		if (GetTree().CurrentScene == this)
+		{
+			ShowGameOver();
+			return;
+		}
+
+		if (PendingShow)
+		{
+			PendingShow = false;
+			ShowStatsScreen(PendingMessage, PendingPlayAudio);
+		}
 	}
-	
+
+	public override void _Input(InputEvent @event)
+	{
+		if (!_advanceRequested)
+		{
+			return;
+		}
+
+		if (@event is InputEventMouseButton mouseButton && mouseButton.Pressed)
+		{
+			GoToMainMenu();
+		}
+		else if (@event is InputEventKey key && key.Pressed && !key.Echo)
+		{
+			GoToMainMenu();
+		}
+		else if (@event is InputEventScreenTouch touch && touch.Pressed)
+		{
+			GoToMainMenu();
+		}
+	}
+
 	/// <summary>
 	/// Shows the game over screen with an optional custom message.
 	/// </summary>
 	public void ShowGameOver(string message = "You have fallen in the dungeon...")
+	{
+		if (!IsNodeReady())
+		{
+			CallDeferred("ShowGameOver", message);
+			return;
+		}
+
+		ShowStatsScreen(message, true);
+	}
+
+	/// <summary>
+	/// Shows the same end-of-run stats screen from non-death flows such as the pause menu.
+	/// </summary>
+	public void ShowSessionStats(string message = "Run summary", bool playAudio = false)
+	{
+		if (!IsNodeReady())
+		{
+			PendingShow = true;
+			PendingMessage = message;
+			PendingPlayAudio = playAudio;
+			return;
+		}
+
+		ShowStatsScreen(message, playAudio);
+	}
+
+	private void ShowStatsScreen(string message, bool playAudio)
 	{
 		if (_messageLabel != null)
 		{
 			_messageLabel.Text = message;
 		}
 
-		// Hide battle transition so it doesn't bleed through during fade-out
-		BattleManager.Instance?.Transitions.Hide();
-		BattleManager.Instance?.ActiveUI.Hide();
+		RefreshStats();
 
-		// Fade out music and play game over sound
+		BattleManager.Instance?.Transitions?.Hide();
+		BattleManager.Instance?.ActiveUI?.Hide();
+
 		AudioManager.Instance?.FadeOutMusic();
-		AudioManager.Instance?.PlayGameOverSound();
+		if (playAudio)
+		{
+			AudioManager.Instance?.PlayGameOverSound();
+		}
 
+		_advanceRequested = true;
 		Visible = true;
 		Input.MouseMode = Input.MouseModeEnum.Visible;
 		GetTree().Paused = true;
 	}
-	
-	public void _on_restart_pressed()
+
+	private void RefreshStats()
 	{
-		GD.Print("Restarting game...");
-		SceneTransition.FadeOut(this, () =>
-		{
-			GetTree().Paused = false;
-			GetTree().ChangeSceneToFile("res://game/entity/dungeon_generator/dungeon_generator.tscn");
-			QueueFree();
-		});
+		ClearContainer(_statsListContainer);
+
+		TaloTelemetry.SessionStatsSnapshot sessionStats = TaloTelemetry.GetSessionSnapshot();
+		AddStatCard(_statsListContainer, "Total questions answered", sessionStats.TotalAnswers.ToString());
+		AddStatCard(_statsListContainer, "Questions answered correctly", sessionStats.CorrectAnswers.ToString());
+		AddStatCard(_statsListContainer, "Questions answered incorrectly", sessionStats.IncorrectAnswers.ToString());
 	}
 
-	public void _on_main_menu_pressed()
+	private void GoToMainMenu()
 	{
-		GD.Print("Returning to main menu...");
+		if (!_advanceRequested)
+		{
+			return;
+		}
+
+		_advanceRequested = false;
 		SceneTransition.FadeOut(this, () =>
 		{
 			GetTree().Paused = false;
 			if (MainMenuScene != null)
+			{
 				GetTree().ChangeSceneToPacked(MainMenuScene);
+			}
 			else
+			{
 				GetTree().ChangeSceneToFile("res://game/ui/main_menu/main_menu.tscn");
+			}
+
 			QueueFree();
 		});
 	}
-	
-	public void _on_quit_pressed()
+
+	private void AddStatCard(VBoxContainer parent, string label, string value)
 	{
-		GD.Print("Quitting game...");
-		GetTree().Quit();
+		if (parent == null)
+		{
+			return;
+		}
+
+		var card = new PanelContainer();
+		card.CustomMinimumSize = new Vector2(0, 88);
+		card.AddThemeStyleboxOverride("panel", CreateCardStyle());
+		parent.AddChild(card);
+
+		var margin = new MarginContainer();
+		margin.AddThemeConstantOverride("margin_left", 16);
+		margin.AddThemeConstantOverride("margin_top", 14);
+		margin.AddThemeConstantOverride("margin_right", 16);
+		margin.AddThemeConstantOverride("margin_bottom", 14);
+		card.AddChild(margin);
+
+		var row = new HBoxContainer();
+		row.AddThemeConstantOverride("separation", 16);
+		margin.AddChild(row);
+
+		var textColumn = new VBoxContainer();
+		textColumn.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
+		textColumn.AddThemeConstantOverride("separation", 2);
+		row.AddChild(textColumn);
+
+		var labelNode = new Label
+		{
+			Text = label,
+			AutowrapMode = TextServer.AutowrapMode.WordSmart
+		};
+		labelNode.AddThemeFontSizeOverride("font_size", 17);
+		labelNode.AddThemeColorOverride("font_color", new Color(0.24f, 0.18f, 0.13f));
+		if (_markerFont != null)
+		{
+			labelNode.AddThemeFontOverride("font", _markerFont);
+		}
+		textColumn.AddChild(labelNode);
+
+		var valueNode = new Label
+		{
+			Text = value,
+			HorizontalAlignment = HorizontalAlignment.Right,
+			AutowrapMode = TextServer.AutowrapMode.WordSmart
+		};
+		valueNode.AddThemeFontSizeOverride("font_size", 30);
+		valueNode.AddThemeColorOverride("font_color", new Color(0.63f, 0.29f, 0.12f));
+		if (_markerFont != null)
+		{
+			valueNode.AddThemeFontOverride("font", _markerFont);
+		}
+		textColumn.AddChild(valueNode);
+	}
+
+	private static void ClearContainer(Container container)
+	{
+		if (container == null)
+		{
+			return;
+		}
+
+		foreach (Node child in container.GetChildren())
+		{
+			container.RemoveChild(child);
+			child.QueueFree();
+		}
+	}
+
+	private void ApplyMarkerFontRecursive(Node node)
+	{
+		if (_markerFont == null || node == null)
+		{
+			return;
+		}
+
+		if (node is Label label)
+		{
+			label.AddThemeFontOverride("font", _markerFont);
+		}
+
+		foreach (Node child in node.GetChildren())
+		{
+			ApplyMarkerFontRecursive(child);
+		}
+	}
+
+	private static StyleBoxFlat CreateCardStyle()
+	{
+		return new StyleBoxFlat
+		{
+			BgColor = new Color(0.97f, 0.94f, 0.86f, 0.98f),
+			BorderWidthLeft = 2,
+			BorderWidthTop = 2,
+			BorderWidthRight = 2,
+			BorderWidthBottom = 2,
+			BorderColor = new Color(0.46f, 0.32f, 0.18f, 0.9f),
+			CornerRadiusTopLeft = 20,
+			CornerRadiusTopRight = 20,
+			CornerRadiusBottomLeft = 20,
+			CornerRadiusBottomRight = 20,
+			ShadowSize = 5,
+			ShadowColor = new Color(0, 0, 0, 0.14f),
+			ContentMarginLeft = 2,
+			ContentMarginTop = 2,
+			ContentMarginRight = 2,
+			ContentMarginBottom = 2
+		};
 	}
 }

--- a/flashcard-roguelike/game/ui/game_over/game_over_menu.tscn
+++ b/flashcard-roguelike/game/ui/game_over/game_over_menu.tscn
@@ -1,80 +1,94 @@
-[gd_scene format=3 uid="uid://cipiibpksub5v"]
+[gd_scene format=3]
 
-[ext_resource type="Script" uid="uid://b8bystywoxvc" path="res://game/ui/game_over/GameOverMenu.cs" id="1_script"]
+[ext_resource type="Script" path="res://game/ui/game_over/GameOverMenu.cs" id="1_script"]
+[ext_resource type="FontFile" path="res://assets/fonts/DryWhiteboardMarker-Regular.ttf" id="2_font"]
 
-[node name="GameOverMenu" type="CanvasLayer" unique_id=780090609]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_main"]
+bg_color = Color(0.98, 0.95, 0.88, 0.98)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.38, 0.26, 0.15, 0.9)
+corner_radius_top_left = 24
+corner_radius_top_right = 24
+corner_radius_bottom_left = 24
+corner_radius_bottom_right = 24
+shadow_size = 10
+shadow_color = Color(0, 0, 0, 0.18)
+
+[node name="GameOverMenu" type="CanvasLayer"]
 process_mode = 3
-layer = 2
+layer = 10
 script = ExtResource("1_script")
 
-[node name="Panel" type="Panel" parent="." unique_id=1018363225]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="ColorRect" type="ColorRect" parent="Panel" unique_id=521833262]
+[node name="Backdrop" type="ColorRect" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0, 0, 0, 0.7)
+color = Color(0.05, 0.04, 0.03, 0.82)
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Panel" unique_id=1001274452]
+[node name="CenterContainer" type="CenterContainer" parent="."]
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -200.0
-offset_top = -150.0
-offset_right = 200.0
-offset_bottom = 150.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 20
 
-[node name="TitleLabel" type="Label" parent="Panel/VBoxContainer" unique_id=527354939]
+[node name="MainPanel" type="PanelContainer" parent="CenterContainer"]
+custom_minimum_size = Vector2(860, 520)
 layout_mode = 2
-theme_override_font_sizes/font_size = 48
+theme_override_styles/panel = SubResource("StyleBoxFlat_main")
+
+[node name="MarginContainer" type="MarginContainer" parent="CenterContainer/MainPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="MainVBox" type="VBoxContainer" parent="CenterContainer/MainPanel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 18
+
+[node name="TitleLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 54
+theme_override_colors/font_color = Color(0.78, 0.18, 0.16, 1)
 text = "GAME OVER"
 horizontal_alignment = 1
-vertical_alignment = 1
 
-[node name="MessageLabel" type="Label" parent="Panel/VBoxContainer" unique_id=1165868571]
+[node name="MessageLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 18
-text = "You have fallen in the dungeon..."
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 20
+theme_override_colors/font_color = Color(0.2, 0.16, 0.13, 1)
+text = "Press anywhere to return to the main menu."
 horizontal_alignment = 1
-vertical_alignment = 1
 autowrap_mode = 2
 
-[node name="Spacer" type="Control" parent="Panel/VBoxContainer" unique_id=383371828]
-custom_minimum_size = Vector2(0, 20)
+[node name="StatsHeaderLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
 layout_mode = 2
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 24
+theme_override_colors/font_color = Color(0.22, 0.15, 0.09, 1)
+text = "Session Stats"
 
-[node name="RestartButton" type="Button" parent="Panel/VBoxContainer" unique_id=1546863700]
-custom_minimum_size = Vector2(200, 50)
+[node name="StatsListContainer" type="VBoxContainer" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
 layout_mode = 2
-size_flags_horizontal = 4
-text = "Try Again"
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 10
 
-[node name="MainMenuButton" type="Button" parent="Panel/VBoxContainer" unique_id=1891151644]
-custom_minimum_size = Vector2(200, 50)
+[node name="FooterLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
 layout_mode = 2
-size_flags_horizontal = 4
-text = "Main Menu"
-
-[node name="QuitButton" type="Button" parent="Panel/VBoxContainer" unique_id=1113316304]
-custom_minimum_size = Vector2(200, 50)
-layout_mode = 2
-size_flags_horizontal = 4
-text = "Quit Game"
-
-[connection signal="pressed" from="Panel/VBoxContainer/RestartButton" to="." method="_on_restart_pressed"]
-[connection signal="pressed" from="Panel/VBoxContainer/MainMenuButton" to="." method="_on_main_menu_pressed"]
-[connection signal="pressed" from="Panel/VBoxContainer/QuitButton" to="." method="_on_quit_pressed"]
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 14
+theme_override_colors/font_color = Color(0.32, 0.24, 0.18, 1)
+text = "Click, tap, or press any key to continue."
+horizontal_alignment = 1

--- a/flashcard-roguelike/game/ui/pause_menue/PauseMenu.cs
+++ b/flashcard-roguelike/game/ui/pause_menue/PauseMenu.cs
@@ -8,6 +8,7 @@ public partial class PauseMenu : CanvasLayer
 	public delegate void ToggleMouseLockEventHandler();
 
 	[Export] PackedScene MainMenu;
+	[Export] PackedScene EndRunStatsScene;
 	private Control _buttonPanelContainer;
 	private SettingsPanel _settingsPanel;
 	private Stack<Control> _panelStack = new Stack<Control>();
@@ -125,8 +126,49 @@ public partial class PauseMenu : CanvasLayer
 	public void _on_main_menu_pressed()
 	{
 		GD.Print("Main Menue Pressed");
-		GetTree().Paused = false;
-		SceneTransition.FadeOut(this, () => GetTree().ChangeSceneToPacked(MainMenu));
+		ShowEndRunStats("Returning to the main menu...");
+	}
+
+	private void ShowEndRunStats(string message)
+	{
+		CloseAll();
+		_buttonPanelContainer.Hide();
+		Visible = false;
+
+		GameOverMenu statsMenu = FindOrCreateEndRunStatsMenu();
+		if (statsMenu != null)
+		{
+			statsMenu.ShowSessionStats(message, false);
+		}
+		else
+		{
+			GetTree().Paused = false;
+			SceneTransition.FadeOut(this, () => GetTree().ChangeSceneToPacked(MainMenu));
+		}
+	}
+
+	private GameOverMenu FindOrCreateEndRunStatsMenu()
+	{
+		GameOverMenu statsMenu = GetTree().Root.GetNodeOrNull<GameOverMenu>("GameOverMenu");
+		if (statsMenu != null)
+		{
+			return statsMenu;
+		}
+
+		PackedScene statsScene = EndRunStatsScene;
+		if (statsScene == null)
+		{
+			statsScene = GD.Load<PackedScene>("res://game/ui/game_over/game_over_menu.tscn");
+		}
+
+		if (statsScene == null)
+		{
+			return null;
+		}
+
+		statsMenu = statsScene.Instantiate<GameOverMenu>();
+		GetTree().Root.AddChild(statsMenu);
+		return statsMenu;
 	}
 
 	public void _on_quit_pressed()

--- a/flashcard-roguelike/game/ui/pause_menue/pause_menu.tscn
+++ b/flashcard-roguelike/game/ui/pause_menue/pause_menu.tscn
@@ -5,6 +5,8 @@
 [ext_resource type="Shader" uid="uid://d2ynk10hjyaab" path="res://game/ui/pause_menue/blur.gdshader" id="2_scxh3"]
 [ext_resource type="Theme" uid="uid://byifovnma6qe7" path="res://game/ui/main_menu/WhiteboardMenuTheme.tres" id="3_whiteboard"]
 [ext_resource type="Script" uid="uid://cxgn2j6exrb1q" path="res://game/ui/pause_menue/SettingsPanel.cs" id="5_1n6di"]
+[ext_resource type="PackedScene" path="res://game/ui/game_over/game_over_menu.tscn" id="6_stats"]
+[ext_resource type="PackedScene" path="res://game/ui/game_over/game_over_menu.tscn" id="6_stats"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_1n6di"]
 shader = ExtResource("2_scxh3")
@@ -22,6 +24,8 @@ font_color = Color(0, 0, 0, 1)
 [node name="PauseMenu" type="CanvasLayer" unique_id=1620896989]
 script = ExtResource("1_f48la")
 MainMenu = ExtResource("2_1n6di")
+EndRunStatsScene = ExtResource("6_stats")
+EndRunStatsScene = ExtResource("6_stats")
 
 [node name="ButtonPanelContainer" type="Control" parent="." unique_id=1746979678]
 layout_mode = 3

--- a/flashcard-roguelike/shared/talo/TaloTelemetry.cs
+++ b/flashcard-roguelike/shared/talo/TaloTelemetry.cs
@@ -1,7 +1,8 @@
 using Godot;
 using System;
 using System.Collections.Generic;
-using Godot.Collections;
+using System.Globalization;
+using GodotDictionary = Godot.Collections.Dictionary;
 
 // Lightweight bridge between C# gameplay code and the Talo Godot plugin autoload.
 // This stays no-op when the plugin is not installed or configured.
@@ -16,9 +17,24 @@ public static class TaloTelemetry
     private static bool _identifyAttempted;
     private static bool _identifySignalConnected;
     private static readonly List<PendingAnswer> _pendingAnswers = new();
+    private static readonly Dictionary<string, float> _sessionStatValues = new();
+    private static int _sessionTotalAnswers;
+    private static int _sessionCorrectAnswers;
+    private static int _sessionIncorrectAnswers;
+
+    public static void ResetSessionStats()
+    {
+        _pendingAnswers.Clear();
+        _sessionStatValues.Clear();
+        _sessionTotalAnswers = 0;
+        _sessionCorrectAnswers = 0;
+        _sessionIncorrectAnswers = 0;
+    }
 
     public static void TrackFlashcardAnswer(bool isCorrect, string action, float difficulty)
     {
+        RecordSessionAnswer(isCorrect);
+
         if (!TryGetTalo(out Node talo))
         {
             return;
@@ -40,6 +56,39 @@ public static class TaloTelemetry
         FlushPendingAnswers(talo);
     }
 
+    public static IReadOnlyList<SessionStatEntry> GetSessionStats()
+    {
+        SessionStatsSnapshot snapshot = GetSessionSnapshot();
+
+        return new List<SessionStatEntry>
+        {
+            new("flashcard_answers_total", "Total questions answered", snapshot.TotalAnswers.ToString(CultureInfo.InvariantCulture)),
+            new("flashcard_answers_correct", "Questions answered correctly", snapshot.CorrectAnswers.ToString(CultureInfo.InvariantCulture)),
+            new("flashcard_answers_incorrect", "Questions answered incorrectly", snapshot.IncorrectAnswers.ToString(CultureInfo.InvariantCulture))
+        };
+    }
+
+    public static SessionStatsSnapshot GetSessionSnapshot()
+    {
+        return new SessionStatsSnapshot(_sessionTotalAnswers, _sessionCorrectAnswers, _sessionIncorrectAnswers);
+    }
+
+    private static void RecordSessionAnswer(bool isCorrect)
+    {
+        _sessionTotalAnswers++;
+        IncrementSessionValue(FlashcardAnswersTotalStat, 1f);
+
+        IncrementSessionValue(isCorrect ? FlashcardAnswersCorrectStat : FlashcardAnswersIncorrectStat, 1f);
+        if (isCorrect)
+        {
+            _sessionCorrectAnswers++;
+        }
+        else
+        {
+            _sessionIncorrectAnswers++;
+        }
+    }
+
     private static void FlushPendingAnswers(Node talo)
     {
         if (_pendingAnswers.Count == 0)
@@ -56,11 +105,11 @@ public static class TaloTelemetry
             {
                 if (eventsApi != null)
                 {
-                    var props = new Dictionary
+                    GodotDictionary props = new GodotDictionary
                     {
                         { "correct", answer.IsCorrect ? "true" : "false" },
                         { "action", answer.Action },
-                        { "difficulty", answer.Difficulty.ToString("0.00") }
+                        { "difficulty", answer.Difficulty.ToString("0.00", CultureInfo.InvariantCulture) }
                     };
 
                     eventsApi.Call("track", FlashcardAnsweredEventName, props);
@@ -80,6 +129,27 @@ public static class TaloTelemetry
         {
             GD.PrintErr($"TaloTelemetry: Failed to track flashcard answer: {ex.Message}");
         }
+    }
+
+    private static void IncrementSessionValue(string statName, float delta)
+    {
+        if (_sessionStatValues.ContainsKey(statName))
+        {
+            _sessionStatValues[statName] += delta;
+            return;
+        }
+
+        _sessionStatValues[statName] = delta;
+    }
+
+    private static float GetSessionValue(string statName)
+    {
+        return _sessionStatValues.TryGetValue(statName, out float value) ? value : 0f;
+    }
+
+    private static string FormatCount(float value)
+    {
+        return Mathf.RoundToInt(value).ToString(CultureInfo.InvariantCulture);
     }
 
     private static bool TryGetTalo(out Node talo)
@@ -176,6 +246,34 @@ public static class TaloTelemetry
         {
             return false;
         }
+    }
+
+    public sealed class SessionStatEntry
+    {
+        public SessionStatEntry(string key, string label, string value)
+        {
+            Key = key;
+            Label = label;
+            Value = value;
+        }
+
+        public string Key { get; }
+        public string Label { get; }
+        public string Value { get; }
+    }
+
+    public readonly struct SessionStatsSnapshot
+    {
+        public SessionStatsSnapshot(int totalAnswers, int correctAnswers, int incorrectAnswers)
+        {
+            TotalAnswers = totalAnswers;
+            CorrectAnswers = correctAnswers;
+            IncorrectAnswers = incorrectAnswers;
+        }
+
+        public int TotalAnswers { get; }
+        public int CorrectAnswers { get; }
+        public int IncorrectAnswers { get; }
     }
 
     private sealed class PendingAnswer


### PR DESCRIPTION
This pull request overhauls the end-of-run (game over) stats screen to provide a more modern, informative, and visually appealing summary of the player's session. The update removes the old button-based game over menu and replaces it with an auto-advancing stats summary that appears both on player death and when abandoning a run from the pause menu. The session statistics are now tracked in memory and displayed in a new card-based UI, using a consistent marker-style font for better readability and style.

Key changes include:

**Game Over UI Redesign and Functionality:**

- Replaced the old button-based game over menu with a new stats summary screen (`GameOverMenu`), which shows session statistics in a visually appealing card format and advances to the main menu on any input. The UI now uses a marker-style font and improved layout, and the code supports both death and non-death flows (like abandoning a run from the pause menu). [[1]](diffhunk://#diff-2d12afe22a57db288770fe83a14b8b455f8f42b2caeac66ea5603157a94de103L2-R267) [[2]](diffhunk://#diff-5b777e6eb2a92a9553b68581a909339a20eef41fc2e60ffa66d855b81fbec71bL1-R94) [[3]](diffhunk://#diff-6dbbae74bcfe39044f4a4a021001903457576725268ebbb97fa261ab5dd86d55R8-R9) [[4]](diffhunk://#diff-6dbbae74bcfe39044f4a4a021001903457576725268ebbb97fa261ab5dd86d55R27-R28)

- The new UI is implemented in `GameOverMenu.cs` and `game_over_menu.tscn`, with the old restart/main menu/quit buttons removed and replaced by a single input-to-continue flow. The pause menu is updated to show the same stats screen when abandoning a run. [[1]](diffhunk://#diff-016f56c3d6d26ba28590776aafa6b890650dd9ce78bfcf568ef5cb19695c3a6fR11) [[2]](diffhunk://#diff-016f56c3d6d26ba28590776aafa6b890650dd9ce78bfcf568ef5cb19695c3a6fR129-R172)

**Session Statistics Tracking:**

- Added in-memory tracking of session statistics (total answers, correct, incorrect) in `TaloTelemetry`, with methods to reset, update, and retrieve a snapshot or list of stats entries. This allows for accurate and up-to-date display of player performance at the end of each run. [[1]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675R20-R37) [[2]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675R59-R91) [[3]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675R134-R154) [[4]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675R251-R278)

- Session stats are reset at the start of each dungeon run to ensure accuracy.

**Visual and Structural Improvements:**

- Updated the scene files to use the new marker font, improved color palette, and card-based layout for stats, ensuring a more polished and consistent look.

- Improved code structure and removed unused imports, ensuring maintainability and clarity.

These changes modernize the end-of-run experience, provide players with immediate feedback on their performance, and set the foundation for further UI and analytics improvements.