### PR TITLE
feat: more stats and talo connection

### DIFF
--- a/flashcard-roguelike/game/entity/battle/BattleManager.cs
+++ b/flashcard-roguelike/game/entity/battle/BattleManager.cs
@@ -152,6 +152,7 @@ public partial class BattleManager : Node
 		{
 			return;
 		}
+
 		//Set enemies player field
 		foreach (var enemy in enemies)
 		{
@@ -311,6 +312,7 @@ public partial class BattleManager : Node
 
 	private void OnEnemyDeath(EnemyFSM enemy)
 	{
+		TaloTelemetry.TrackEnemiesDefeated();
 		_uiCoordinator.LogMessage($"{enemy.Name} was defeated!");
 		_uiCoordinator.UpdateHealthUI();
 		_state.RemoveEnemy(enemy);

--- a/flashcard-roguelike/game/entity/dungeon_generator/rooms/Room.cs
+++ b/flashcard-roguelike/game/entity/dungeon_generator/rooms/Room.cs
@@ -21,6 +21,7 @@ public partial class Room : Node3D
 			// Save player reference for use in event rooms, etc.
 			_player = body as Player;
 			GD.Print("Player entered room: " + Name + " with player reference: " + _player.Name);
+			TaloTelemetry.TrackRoomsEntered();
 
 			Node3D Exits = GetNode<Node3D>("Exits");
 			var children = Exits.GetChildren();

--- a/flashcard-roguelike/game/entity/enemy_fsm/EnemyFSM.cs
+++ b/flashcard-roguelike/game/entity/enemy_fsm/EnemyFSM.cs
@@ -51,6 +51,7 @@ public partial class EnemyFSM : CharacterBody3D
 			*/
 			var room = GetParent<Node3D>().GetParent<Node3D>();
 			List<EnemyFSM> enemiesInRoom = GetParent<Node3D>().GetChildren().OfType<EnemyFSM>().ToList();
+			TaloTelemetry.TrackEnemiesFaced(enemiesInRoom.Count);
 			BattleManager.Instance.StartBattle(player, enemiesInRoom, room);
 		}
 	}

--- a/flashcard-roguelike/game/entity/item/Item.cs
+++ b/flashcard-roguelike/game/entity/item/Item.cs
@@ -43,6 +43,8 @@ public partial class Item : Interactable
 			foreach (var effect in _resource.PickupEffects)
 				effect.Apply(player, new ItemInstance(_resource));
 		}
+
+		TaloTelemetry.TrackItemsPickedUp();
 		
 
 		QueueFree();

--- a/flashcard-roguelike/game/entity/treasure/TreasureChest.cs
+++ b/flashcard-roguelike/game/entity/treasure/TreasureChest.cs
@@ -47,6 +47,7 @@ public partial class TreasureChest : Interactable
 	{
 		if (IsOpen) return;
 		IsOpen = true;
+		TaloTelemetry.TrackChestsOpened();
 
 		if (_lidMesh != null)
 		{

--- a/flashcard-roguelike/game/entity/treasure/TreasureItem.cs
+++ b/flashcard-roguelike/game/entity/treasure/TreasureItem.cs
@@ -92,6 +92,7 @@ public partial class TreasureItem : Node3D
 	public void Collect()
 	{
 		GD.Print($"Collected {ItemName} (Value: {Value}, Rarity: {Rarity})");
+		TaloTelemetry.TrackItemsPickedUp();
 		EmitSignal(SignalName.ItemCollected, this);
 		QueueFree();
 	}

--- a/flashcard-roguelike/game/ui/game_over/GameOverMenu.cs
+++ b/flashcard-roguelike/game/ui/game_over/GameOverMenu.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 /// <summary>
 /// Game over screen displayed when the player dies.
-/// Shows only the tracked Talo session stats and returns to the main menu on input.
+/// Shows the tracked session stats and returns to the main menu on input.
 /// </summary>
 public partial class GameOverMenu : CanvasLayer
 {
@@ -19,7 +19,7 @@ public partial class GameOverMenu : CanvasLayer
 	private FontFile _markerFont;
 	private Label _messageLabel;
 	private Label _statsHeaderLabel;
-	private VBoxContainer _statsListContainer;
+	private GridContainer _statsListContainer;
 	private bool _advanceRequested;
 
 	public override void _Ready()
@@ -27,7 +27,7 @@ public partial class GameOverMenu : CanvasLayer
 		_markerFont = GD.Load<FontFile>(MarkerFontPath);
 		_messageLabel = GetNodeOrNull<Label>("CenterContainer/MainPanel/MarginContainer/MainVBox/MessageLabel");
 		_statsHeaderLabel = GetNodeOrNull<Label>("CenterContainer/MainPanel/MarginContainer/MainVBox/StatsHeaderLabel");
-		_statsListContainer = GetNodeOrNull<VBoxContainer>("CenterContainer/MainPanel/MarginContainer/MainVBox/StatsListContainer");
+		_statsListContainer = GetNodeOrNull<GridContainer>("CenterContainer/MainPanel/MarginContainer/MainVBox/StatsListContainer");
 
 		ApplyMarkerFontRecursive(this);
 
@@ -126,10 +126,10 @@ public partial class GameOverMenu : CanvasLayer
 	{
 		ClearContainer(_statsListContainer);
 
-		TaloTelemetry.SessionStatsSnapshot sessionStats = TaloTelemetry.GetSessionSnapshot();
-		AddStatCard(_statsListContainer, "Total questions answered", sessionStats.TotalAnswers.ToString());
-		AddStatCard(_statsListContainer, "Questions answered correctly", sessionStats.CorrectAnswers.ToString());
-		AddStatCard(_statsListContainer, "Questions answered incorrectly", sessionStats.IncorrectAnswers.ToString());
+		foreach (TaloTelemetry.SessionStatEntry stat in TaloTelemetry.GetSessionStats())
+		{
+			AddStatCard(_statsListContainer, stat.Label, stat.Value);
+		}
 	}
 
 	private void GoToMainMenu()
@@ -156,7 +156,7 @@ public partial class GameOverMenu : CanvasLayer
 		});
 	}
 
-	private void AddStatCard(VBoxContainer parent, string label, string value)
+	private void AddStatCard(Container parent, string label, string value)
 	{
 		if (parent == null)
 		{
@@ -164,7 +164,8 @@ public partial class GameOverMenu : CanvasLayer
 		}
 
 		var card = new PanelContainer();
-		card.CustomMinimumSize = new Vector2(0, 88);
+		card.CustomMinimumSize = new Vector2(0, 72);
+		card.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
 		card.AddThemeStyleboxOverride("panel", CreateCardStyle());
 		parent.AddChild(card);
 
@@ -189,7 +190,7 @@ public partial class GameOverMenu : CanvasLayer
 			Text = label,
 			AutowrapMode = TextServer.AutowrapMode.WordSmart
 		};
-		labelNode.AddThemeFontSizeOverride("font_size", 17);
+		labelNode.AddThemeFontSizeOverride("font_size", 15);
 		labelNode.AddThemeColorOverride("font_color", new Color(0.24f, 0.18f, 0.13f));
 		if (_markerFont != null)
 		{
@@ -203,7 +204,7 @@ public partial class GameOverMenu : CanvasLayer
 			HorizontalAlignment = HorizontalAlignment.Right,
 			AutowrapMode = TextServer.AutowrapMode.WordSmart
 		};
-		valueNode.AddThemeFontSizeOverride("font_size", 30);
+		valueNode.AddThemeFontSizeOverride("font_size", 24);
 		valueNode.AddThemeColorOverride("font_color", new Color(0.63f, 0.29f, 0.12f));
 		if (_markerFont != null)
 		{

--- a/flashcard-roguelike/game/ui/game_over/game_over_menu.tscn
+++ b/flashcard-roguelike/game/ui/game_over/game_over_menu.tscn
@@ -1,7 +1,7 @@
-[gd_scene format=3]
+[gd_scene format=3 uid="uid://xis5gf6wut10"]
 
-[ext_resource type="Script" path="res://game/ui/game_over/GameOverMenu.cs" id="1_script"]
-[ext_resource type="FontFile" path="res://assets/fonts/DryWhiteboardMarker-Regular.ttf" id="2_font"]
+[ext_resource type="Script" uid="uid://b8bystywoxvc" path="res://game/ui/game_over/GameOverMenu.cs" id="1_script"]
+[ext_resource type="FontFile" uid="uid://bwy3w3j0me71b" path="res://assets/fonts/DryWhiteboardMarker-Regular.ttf" id="2_font"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_main"]
 bg_color = Color(0.98, 0.95, 0.88, 0.98)
@@ -12,18 +12,17 @@ border_width_bottom = 2
 border_color = Color(0.38, 0.26, 0.15, 0.9)
 corner_radius_top_left = 24
 corner_radius_top_right = 24
-corner_radius_bottom_left = 24
 corner_radius_bottom_right = 24
-shadow_size = 10
+corner_radius_bottom_left = 24
 shadow_color = Color(0, 0, 0, 0.18)
+shadow_size = 10
 
-[node name="GameOverMenu" type="CanvasLayer"]
+[node name="GameOverMenu" type="CanvasLayer" unique_id=395216041]
 process_mode = 3
 layer = 10
 script = ExtResource("1_script")
 
-[node name="Backdrop" type="ColorRect" parent="."]
-layout_mode = 1
+[node name="Backdrop" type="ColorRect" parent="." unique_id=2015551207]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -31,64 +30,65 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.05, 0.04, 0.03, 0.82)
 
-[node name="CenterContainer" type="CenterContainer" parent="."]
-layout_mode = 1
+[node name="CenterContainer" type="CenterContainer" parent="." unique_id=2024712742]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="MainPanel" type="PanelContainer" parent="CenterContainer"]
-custom_minimum_size = Vector2(860, 520)
+[node name="MainPanel" type="PanelContainer" parent="CenterContainer" unique_id=361003437]
+custom_minimum_size = Vector2(1040, 720)
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_main")
 
-[node name="MarginContainer" type="MarginContainer" parent="CenterContainer/MainPanel"]
+[node name="MarginContainer" type="MarginContainer" parent="CenterContainer/MainPanel" unique_id=1479757156]
 layout_mode = 2
 theme_override_constants/margin_left = 24
 theme_override_constants/margin_top = 24
 theme_override_constants/margin_right = 24
 theme_override_constants/margin_bottom = 24
 
-[node name="MainVBox" type="VBoxContainer" parent="CenterContainer/MainPanel/MarginContainer"]
+[node name="MainVBox" type="VBoxContainer" parent="CenterContainer/MainPanel/MarginContainer" unique_id=766003528]
 layout_mode = 2
-theme_override_constants/separation = 18
+theme_override_constants/separation = 14
 
-[node name="TitleLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
+[node name="TitleLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox" unique_id=182607670]
 layout_mode = 2
-theme_override_fonts/font = ExtResource("2_font")
-theme_override_font_sizes/font_size = 54
 theme_override_colors/font_color = Color(0.78, 0.18, 0.16, 1)
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 48
 text = "GAME OVER"
 horizontal_alignment = 1
 
-[node name="MessageLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
+[node name="MessageLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox" unique_id=180056133]
 layout_mode = 2
-theme_override_fonts/font = ExtResource("2_font")
-theme_override_font_sizes/font_size = 20
 theme_override_colors/font_color = Color(0.2, 0.16, 0.13, 1)
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 18
 text = "Press anywhere to return to the main menu."
 horizontal_alignment = 1
 autowrap_mode = 2
 
-[node name="StatsHeaderLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
+[node name="StatsHeaderLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox" unique_id=1637770715]
 layout_mode = 2
-theme_override_fonts/font = ExtResource("2_font")
-theme_override_font_sizes/font_size = 24
 theme_override_colors/font_color = Color(0.22, 0.15, 0.09, 1)
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 22
 text = "Session Stats"
 
-[node name="StatsListContainer" type="VBoxContainer" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
+[node name="StatsListContainer" type="GridContainer" parent="CenterContainer/MainPanel/MarginContainer/MainVBox" unique_id=792468478]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme_override_constants/separation = 10
+theme_override_constants/h_separation = 12
+theme_override_constants/v_separation = 10
+columns = 2
 
-[node name="FooterLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox"]
+[node name="FooterLabel" type="Label" parent="CenterContainer/MainPanel/MarginContainer/MainVBox" unique_id=1117936091]
 layout_mode = 2
-theme_override_fonts/font = ExtResource("2_font")
-theme_override_font_sizes/font_size = 14
 theme_override_colors/font_color = Color(0.32, 0.24, 0.18, 1)
+theme_override_fonts/font = ExtResource("2_font")
+theme_override_font_sizes/font_size = 13
 text = "Click, tap, or press any key to continue."
 horizontal_alignment = 1

--- a/flashcard-roguelike/shared/components/attack/AttackComponent.cs
+++ b/flashcard-roguelike/shared/components/attack/AttackComponent.cs
@@ -32,6 +32,10 @@ public partial class AttackComponent : Node
 			float damage = BaseDamage * damageMultiplier;
 			GD.Print($"{GetParent().Name} attacked {target.Name} for {damage} damage!");
 			healthComponent.TakeDamage(damage);
+			if (GetParent() is Player)
+			{
+				TaloTelemetry.TrackDamageDealt(damage);
+			}
 			return true;
 		}
 		else

--- a/flashcard-roguelike/shared/components/health/HealthComponent.cs
+++ b/flashcard-roguelike/shared/components/health/HealthComponent.cs
@@ -44,6 +44,11 @@ public partial class HealthComponent : Node
 
 		if (IsPlayer)
 		{
+			TaloTelemetry.TrackDamageTaken(damage);
+		}
+
+		if (IsPlayer)
+		{
 			ShakeCamera();
 			FlashDamageOverlay();
 		}

--- a/flashcard-roguelike/shared/talo/TaloTelemetry.cs
+++ b/flashcard-roguelike/shared/talo/TaloTelemetry.cs
@@ -8,278 +8,422 @@ using GodotDictionary = Godot.Collections.Dictionary;
 // This stays no-op when the plugin is not installed or configured.
 public static class TaloTelemetry
 {
-    private const string FlashcardAnsweredEventName = "flashcard_answered";
-    private const string FlashcardAnswersTotalStat = "flashcard_answers_total";
-    private const string FlashcardAnswersCorrectStat = "flashcard_answers_correct";
-    private const string FlashcardAnswersIncorrectStat = "flashcard_answers_incorrect";
+	private const string FlashcardAnsweredEventName = "flashcard_answered";
+	private const string FlashcardAnswersTotalStat = "flashcard_answers_total";
+	private const string FlashcardAnswersCorrectStat = "flashcard_answers_correct";
+	private const string FlashcardAnswersIncorrectStat = "flashcard_answers_incorrect";
+	private const string EnemiesFacedTotalStat = "enemies_faced_total";
+	private const string EnemiesDefeatedTotalStat = "enemies_defeated_total";
+	private const string RoomsEnteredTotalStat = "rooms_entered_total";
+	private const string ChestsOpenedTotalStat = "chests_opened_total";
+	private const string DamageTakenTotalStat = "damage_taken_total";
+	private const string DamageDealtTotalStat = "damage_dealt_total";
+	private const string ItemsPickedUpTotalStat = "items_picked_up_total";
 
-    private static bool _missingPluginLogged;
-    private static bool _identifyAttempted;
-    private static bool _identifySignalConnected;
-    private static readonly List<PendingAnswer> _pendingAnswers = new();
-    private static readonly Dictionary<string, float> _sessionStatValues = new();
-    private static int _sessionTotalAnswers;
-    private static int _sessionCorrectAnswers;
-    private static int _sessionIncorrectAnswers;
+	private static bool _missingPluginLogged;
+	private static bool _identifyAttempted;
+	private static bool _identifySignalConnected;
+	private static readonly List<PendingAnswer> _pendingAnswers = new();
+	private static readonly List<PendingStatUpdate> _pendingStats = new();
+	private static readonly Dictionary<string, float> _sessionStatValues = new();
+	private static int _sessionTotalAnswers;
+	private static int _sessionCorrectAnswers;
+	private static int _sessionIncorrectAnswers;
 
-    public static void ResetSessionStats()
-    {
-        _pendingAnswers.Clear();
-        _sessionStatValues.Clear();
-        _sessionTotalAnswers = 0;
-        _sessionCorrectAnswers = 0;
-        _sessionIncorrectAnswers = 0;
-    }
+	public static void ResetSessionStats()
+	{
+		_pendingAnswers.Clear();
+		_pendingStats.Clear();
+		_sessionStatValues.Clear();
+		_sessionTotalAnswers = 0;
+		_sessionCorrectAnswers = 0;
+		_sessionIncorrectAnswers = 0;
+	}
 
-    public static void TrackFlashcardAnswer(bool isCorrect, string action, float difficulty)
-    {
-        RecordSessionAnswer(isCorrect);
+	public static void TrackEnemiesFaced(int count = 1)
+	{
+		TrackCountStat(EnemiesFacedTotalStat, count, trackToTalo: true);
+	}
 
-        if (!TryGetTalo(out Node talo))
-        {
-            return;
-        }
+	public static void TrackEnemiesDefeated(int count = 1)
+	{
+		TrackCountStat(EnemiesDefeatedTotalStat, count);
+	}
 
-        _pendingAnswers.Add(new PendingAnswer
-        {
-            IsCorrect = isCorrect,
-            Action = string.IsNullOrWhiteSpace(action) ? "unknown" : action,
-            Difficulty = difficulty
-        });
+	public static void TrackRoomsEntered(int count = 1)
+	{
+		TrackCountStat(RoomsEnteredTotalStat, count, trackToTalo: true);
+	}
 
-        TryIdentifyAnonymousPlayer(talo);
-        if (!IsPlayerIdentified(talo))
-        {
-            return;
-        }
+	public static void TrackChestsOpened(int count = 1)
+	{
+		TrackCountStat(ChestsOpenedTotalStat, count, trackToTalo: true);
+	}
 
-        FlushPendingAnswers(talo);
-    }
+	public static void TrackDamageTaken(float amount)
+	{
+		TrackAmountStat(DamageTakenTotalStat, amount);
+	}
 
-    public static IReadOnlyList<SessionStatEntry> GetSessionStats()
-    {
-        SessionStatsSnapshot snapshot = GetSessionSnapshot();
+	public static void TrackDamageDealt(float amount)
+	{
+		TrackAmountStat(DamageDealtTotalStat, amount);
+	}
 
-        return new List<SessionStatEntry>
-        {
-            new("flashcard_answers_total", "Total questions answered", snapshot.TotalAnswers.ToString(CultureInfo.InvariantCulture)),
-            new("flashcard_answers_correct", "Questions answered correctly", snapshot.CorrectAnswers.ToString(CultureInfo.InvariantCulture)),
-            new("flashcard_answers_incorrect", "Questions answered incorrectly", snapshot.IncorrectAnswers.ToString(CultureInfo.InvariantCulture))
-        };
-    }
+	public static void TrackItemsPickedUp(int count = 1)
+	{
+		TrackCountStat(ItemsPickedUpTotalStat, count);
+	}
 
-    public static SessionStatsSnapshot GetSessionSnapshot()
-    {
-        return new SessionStatsSnapshot(_sessionTotalAnswers, _sessionCorrectAnswers, _sessionIncorrectAnswers);
-    }
+	public static void TrackFlashcardAnswer(bool isCorrect, string action, float difficulty)
+	{
+		RecordSessionAnswer(isCorrect);
 
-    private static void RecordSessionAnswer(bool isCorrect)
-    {
-        _sessionTotalAnswers++;
-        IncrementSessionValue(FlashcardAnswersTotalStat, 1f);
+		if (!TryGetTalo(out Node talo))
+		{
+			return;
+		}
 
-        IncrementSessionValue(isCorrect ? FlashcardAnswersCorrectStat : FlashcardAnswersIncorrectStat, 1f);
-        if (isCorrect)
-        {
-            _sessionCorrectAnswers++;
-        }
-        else
-        {
-            _sessionIncorrectAnswers++;
-        }
-    }
+		_pendingAnswers.Add(new PendingAnswer
+		{
+			IsCorrect = isCorrect,
+			Action = string.IsNullOrWhiteSpace(action) ? "unknown" : action,
+			Difficulty = difficulty
+		});
 
-    private static void FlushPendingAnswers(Node talo)
-    {
-        if (_pendingAnswers.Count == 0)
-        {
-            return;
-        }
+		TryIdentifyAnonymousPlayer(talo);
+		if (!IsPlayerIdentified(talo))
+		{
+			return;
+		}
 
-        try
-        {
-            GodotObject eventsApi = talo.Get("events").AsGodotObject();
-            GodotObject statsApi = talo.Get("stats").AsGodotObject();
+		FlushPendingAnswers(talo);
+	}
 
-            foreach (var answer in _pendingAnswers)
-            {
-                if (eventsApi != null)
-                {
-                    GodotDictionary props = new GodotDictionary
-                    {
-                        { "correct", answer.IsCorrect ? "true" : "false" },
-                        { "action", answer.Action },
-                        { "difficulty", answer.Difficulty.ToString("0.00", CultureInfo.InvariantCulture) }
-                    };
+	public static IReadOnlyList<SessionStatEntry> GetSessionStats()
+	{
+		return new List<SessionStatEntry>
+		{
+			new(FlashcardAnswersTotalStat, "Total questions answered", FormatCount(GetSessionValue(FlashcardAnswersTotalStat))),
+			new(RoomsEnteredTotalStat, "Rooms entered", FormatCount(GetSessionValue(RoomsEnteredTotalStat))),
+			new(FlashcardAnswersCorrectStat, "Questions answered correctly", FormatCount(GetSessionValue(FlashcardAnswersCorrectStat))),
+			new(FlashcardAnswersIncorrectStat, "Questions answered incorrectly", FormatCount(GetSessionValue(FlashcardAnswersIncorrectStat))),
+			new(EnemiesFacedTotalStat, "Enemies faced", FormatCount(GetSessionValue(EnemiesFacedTotalStat))),
+			new(EnemiesDefeatedTotalStat, "Enemies defeated", FormatCount(GetSessionValue(EnemiesDefeatedTotalStat))),
+			new(DamageDealtTotalStat, "Damage dealt", FormatAmount(GetSessionValue(DamageDealtTotalStat))),
+			new(DamageTakenTotalStat, "Damage taken", FormatAmount(GetSessionValue(DamageTakenTotalStat))),
+			new(ChestsOpenedTotalStat, "Treasure chests opened", FormatCount(GetSessionValue(ChestsOpenedTotalStat))),
+			new(ItemsPickedUpTotalStat, "Items picked up", FormatCount(GetSessionValue(ItemsPickedUpTotalStat)))
+		};
+	}
 
-                    eventsApi.Call("track", FlashcardAnsweredEventName, props);
-                }
+	public static SessionStatsSnapshot GetSessionSnapshot()
+	{
+		return new SessionStatsSnapshot(_sessionTotalAnswers, _sessionCorrectAnswers, _sessionIncorrectAnswers);
+	}
 
-                if (statsApi != null)
-                {
-                    string outcomeStat = answer.IsCorrect ? FlashcardAnswersCorrectStat : FlashcardAnswersIncorrectStat;
-                    statsApi.Call("track", FlashcardAnswersTotalStat, 1.0f);
-                    statsApi.Call("track", outcomeStat, 1.0f);
-                }
-            }
+	private static void RecordSessionAnswer(bool isCorrect)
+	{
+		_sessionTotalAnswers++;
+		IncrementSessionValue(FlashcardAnswersTotalStat, 1f);
 
-            _pendingAnswers.Clear();
-        }
-        catch (Exception ex)
-        {
-            GD.PrintErr($"TaloTelemetry: Failed to track flashcard answer: {ex.Message}");
-        }
-    }
+		IncrementSessionValue(isCorrect ? FlashcardAnswersCorrectStat : FlashcardAnswersIncorrectStat, 1f);
+		if (isCorrect)
+		{
+			_sessionCorrectAnswers++;
+		}
+		else
+		{
+			_sessionIncorrectAnswers++;
+		}
+	}
 
-    private static void IncrementSessionValue(string statName, float delta)
-    {
-        if (_sessionStatValues.ContainsKey(statName))
-        {
-            _sessionStatValues[statName] += delta;
-            return;
-        }
+	private static void FlushPendingAnswers(Node talo)
+	{
+		if (_pendingAnswers.Count == 0)
+		{
+			return;
+		}
 
-        _sessionStatValues[statName] = delta;
-    }
+		try
+		{
+			GodotObject eventsApi = talo.Get("events").AsGodotObject();
+			GodotObject statsApi = talo.Get("stats").AsGodotObject();
 
-    private static float GetSessionValue(string statName)
-    {
-        return _sessionStatValues.TryGetValue(statName, out float value) ? value : 0f;
-    }
+			foreach (var answer in _pendingAnswers)
+			{
+				if (eventsApi != null)
+				{
+					GodotDictionary props = new GodotDictionary
+					{
+						{ "correct", answer.IsCorrect ? "true" : "false" },
+						{ "action", answer.Action },
+						{ "difficulty", answer.Difficulty.ToString("0.00", CultureInfo.InvariantCulture) }
+					};
 
-    private static string FormatCount(float value)
-    {
-        return Mathf.RoundToInt(value).ToString(CultureInfo.InvariantCulture);
-    }
+					eventsApi.Call("track", FlashcardAnsweredEventName, props);
+				}
 
-    private static bool TryGetTalo(out Node talo)
-    {
-        talo = null;
+				if (statsApi != null)
+				{
+					string outcomeStat = answer.IsCorrect ? FlashcardAnswersCorrectStat : FlashcardAnswersIncorrectStat;
+					TrackTaloStat(talo, FlashcardAnswersTotalStat, 1.0f);
+					TrackTaloStat(talo, outcomeStat, 1.0f);
+				}
+			}
 
-        if (Engine.GetMainLoop() is not SceneTree tree)
-        {
-            return false;
-        }
+			_pendingAnswers.Clear();
+		}
+		catch (Exception ex)
+		{
+			GD.PrintErr($"TaloTelemetry: Failed to track flashcard answer: {ex.Message}");
+		}
+	}
 
-        talo = tree.Root.GetNodeOrNull<Node>("/root/Talo");
-        if (talo != null)
-        {
-            return true;
-        }
+	private static void IncrementSessionValue(string statName, float delta)
+	{
+		if (_sessionStatValues.ContainsKey(statName))
+		{
+			_sessionStatValues[statName] += delta;
+			return;
+		}
 
-        if (!_missingPluginLogged)
-        {
-            GD.Print("TaloTelemetry: Talo plugin autoload '/root/Talo' not found. Telemetry is disabled.");
-            _missingPluginLogged = true;
-        }
+		_sessionStatValues[statName] = delta;
+	}
 
-        return false;
-    }
+	private static void TrackCountStat(string statName, int count, bool trackToTalo = false)
+	{
+		if (count <= 0)
+		{
+			return;
+		}
 
-    private static void TryIdentifyAnonymousPlayer(Node talo)
-    {
-        try
-        {
-            GodotObject playersApi = talo.Get("players").AsGodotObject();
-            if (playersApi == null)
-            {
-                return;
-            }
+		IncrementSessionValue(statName, count);
 
-            TryConnectIdentifiedSignal(playersApi);
+		if (!trackToTalo)
+		{
+			return;
+		}
 
-            if (_identifyAttempted)
-            {
-                return;
-            }
+		if (!TryGetTalo(out Node talo) || !IsPlayerIdentified(talo))
+		{
+			for (int i = 0; i < count; i++)
+			{
+				_pendingStats.Add(new PendingStatUpdate(statName, 1.0f));
+			}
+			return;
+		}
 
-            _identifyAttempted = true;
+		for (int i = 0; i < count; i++)
+		{
+			TrackTaloStat(talo, statName, 1.0f);
+		}
+	}
 
-            string identifier = OS.GetUniqueId();
-            if (string.IsNullOrWhiteSpace(identifier))
-            {
-                identifier = Guid.NewGuid().ToString("N");
-            }
+	private static void TrackAmountStat(string statName, float amount)
+	{
+		if (amount <= 0f)
+		{
+			return;
+		}
 
-            // The plugin handles this asynchronously; this call simply starts identification.
-            playersApi.Call("identify", "device", identifier);
-        }
-        catch (Exception ex)
-        {
-            GD.PrintErr($"TaloTelemetry: Failed to identify player: {ex.Message}");
-        }
-    }
+		IncrementSessionValue(statName, amount);
+	}
 
-    private static void TryConnectIdentifiedSignal(GodotObject playersApi)
-    {
-        if (_identifySignalConnected || playersApi is not Node playersNode)
-        {
-            return;
-        }
+	private static float GetSessionValue(string statName)
+	{
+		return _sessionStatValues.TryGetValue(statName, out float value) ? value : 0f;
+	}
 
-        Callable onIdentified = Callable.From<GodotObject>(OnPlayerIdentified);
-        if (!playersNode.IsConnected("identified", onIdentified))
-        {
-            playersNode.Connect("identified", onIdentified);
-        }
+	private static string FormatCount(float value)
+	{
+		return Mathf.RoundToInt(value).ToString(CultureInfo.InvariantCulture);
+	}
 
-        _identifySignalConnected = true;
-    }
+	private static string FormatAmount(float value)
+	{
+		return value.ToString("0.##", CultureInfo.InvariantCulture);
+	}
 
-    private static void OnPlayerIdentified(GodotObject _player)
-    {
-        if (!TryGetTalo(out Node talo))
-        {
-            return;
-        }
+	private static void TrackTaloStat(Node talo, string statName, float delta)
+	{
+		try
+		{
+			GodotObject statsApi = talo.Get("stats").AsGodotObject();
+			if (statsApi != null)
+			{
+				statsApi.Call("track", statName, delta);
+			}
+		}
+		catch (Exception ex)
+		{
+			GD.PrintErr($"TaloTelemetry: Failed to track stat '{statName}': {ex.Message}");
+		}
+	}
 
-        FlushPendingAnswers(talo);
-    }
+	private static bool TryGetTalo(out Node talo)
+	{
+		talo = null;
 
-    private static bool IsPlayerIdentified(Node talo)
-    {
-        try
-        {
-            return talo.Get("current_alias").AsGodotObject() != null;
-        }
-        catch
-        {
-            return false;
-        }
-    }
+		if (Engine.GetMainLoop() is not SceneTree tree)
+		{
+			return false;
+		}
 
-    public sealed class SessionStatEntry
-    {
-        public SessionStatEntry(string key, string label, string value)
-        {
-            Key = key;
-            Label = label;
-            Value = value;
-        }
+		talo = tree.Root.GetNodeOrNull<Node>("/root/Talo");
+		if (talo != null)
+		{
+			return true;
+		}
 
-        public string Key { get; }
-        public string Label { get; }
-        public string Value { get; }
-    }
+		if (!_missingPluginLogged)
+		{
+			GD.Print("TaloTelemetry: Talo plugin autoload '/root/Talo' not found. Telemetry is disabled.");
+			_missingPluginLogged = true;
+		}
 
-    public readonly struct SessionStatsSnapshot
-    {
-        public SessionStatsSnapshot(int totalAnswers, int correctAnswers, int incorrectAnswers)
-        {
-            TotalAnswers = totalAnswers;
-            CorrectAnswers = correctAnswers;
-            IncorrectAnswers = incorrectAnswers;
-        }
+		return false;
+	}
 
-        public int TotalAnswers { get; }
-        public int CorrectAnswers { get; }
-        public int IncorrectAnswers { get; }
-    }
+	private static void TryIdentifyAnonymousPlayer(Node talo)
+	{
+		try
+		{
+			GodotObject playersApi = talo.Get("players").AsGodotObject();
+			if (playersApi == null)
+			{
+				return;
+			}
 
-    private sealed class PendingAnswer
-    {
-        public bool IsCorrect { get; init; }
-        public string Action { get; init; }
-        public float Difficulty { get; init; }
-    }
+			TryConnectIdentifiedSignal(playersApi);
+
+			if (_identifyAttempted)
+			{
+				return;
+			}
+
+			_identifyAttempted = true;
+
+			string identifier = OS.GetUniqueId();
+			if (string.IsNullOrWhiteSpace(identifier))
+			{
+				identifier = Guid.NewGuid().ToString("N");
+			}
+
+			// The plugin handles this asynchronously; this call simply starts identification.
+			playersApi.Call("identify", "device", identifier);
+		}
+		catch (Exception ex)
+		{
+			GD.PrintErr($"TaloTelemetry: Failed to identify player: {ex.Message}");
+		}
+	}
+
+	private static void TryConnectIdentifiedSignal(GodotObject playersApi)
+	{
+		if (_identifySignalConnected || playersApi is not Node playersNode)
+		{
+			return;
+		}
+
+		Callable onIdentified = Callable.From<GodotObject>(OnPlayerIdentified);
+		if (!playersNode.IsConnected("identified", onIdentified))
+		{
+			playersNode.Connect("identified", onIdentified);
+		}
+
+		_identifySignalConnected = true;
+	}
+
+	private static void OnPlayerIdentified(GodotObject _player)
+	{
+		if (!TryGetTalo(out Node talo))
+		{
+			return;
+		}
+
+		FlushPendingAnswers(talo);
+		FlushPendingStats(talo);
+	}
+
+	private static void FlushPendingStats(Node talo)
+	{
+		if (_pendingStats.Count == 0)
+		{
+			return;
+		}
+
+		try
+		{
+			foreach (PendingStatUpdate stat in _pendingStats)
+			{
+				TrackTaloStat(talo, stat.StatName, stat.Amount);
+			}
+
+			_pendingStats.Clear();
+		}
+		catch (Exception ex)
+		{
+			GD.PrintErr($"TaloTelemetry: Failed to track pending stats: {ex.Message}");
+		}
+	}
+
+	private static bool IsPlayerIdentified(Node talo)
+	{
+		try
+		{
+			return talo.Get("current_alias").AsGodotObject() != null;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	public sealed class SessionStatEntry
+	{
+		public SessionStatEntry(string key, string label, string value)
+		{
+			Key = key;
+			Label = label;
+			Value = value;
+		}
+
+		public string Key { get; }
+		public string Label { get; }
+		public string Value { get; }
+	}
+
+	public readonly struct SessionStatsSnapshot
+	{
+		public SessionStatsSnapshot(int totalAnswers, int correctAnswers, int incorrectAnswers)
+		{
+			TotalAnswers = totalAnswers;
+			CorrectAnswers = correctAnswers;
+			IncorrectAnswers = incorrectAnswers;
+		}
+
+		public int TotalAnswers { get; }
+		public int CorrectAnswers { get; }
+		public int IncorrectAnswers { get; }
+	}
+
+	private sealed class PendingAnswer
+	{
+		public bool IsCorrect { get; init; }
+		public string Action { get; init; }
+		public float Difficulty { get; init; }
+	}
+
+	private sealed class PendingStatUpdate
+	{
+		public PendingStatUpdate(string statName, float amount)
+		{
+			StatName = statName;
+			Amount = amount;
+		}
+
+		public string StatName { get; }
+		public float Amount { get; }
+	}
 }


### PR DESCRIPTION
This pull request adds comprehensive session stat tracking and display to the game, expanding the telemetry system (`TaloTelemetry`) to monitor a wider range of player actions and updating the Game Over UI to present these new stats. It introduces tracking for enemies faced/defeated, rooms entered, chests opened, damage dealt/taken, and items picked up, and updates the Game Over screen to show all these stats in a more visually organized grid format.

**Telemetry system enhancements:**

* Added new stat tracking methods and constants to `TaloTelemetry` for: enemies faced, enemies defeated, rooms entered, chests opened, damage taken, damage dealt, and items picked up. These are now incremented at appropriate gameplay events throughout the codebase. [[1]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675R15-R27) [[2]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675R36-R77) [[3]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675R194-R232)
* Implemented stat formatting and reporting improvements, including support for both count and amount stats, and ensured stats are sent to the Talo API when available. [[1]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675R243-R263) [[2]](diffhunk://#diff-9c3404aad25aa739a591b32b0420b63989648794813f653d8dae3b3ccf11c675L121-R171)

**Gameplay integration:**

* Inserted calls to the new telemetry tracking methods at key points: when enemies are faced or defeated, rooms entered, chests opened, items picked up, and when the player deals or takes damage. [[1]](diffhunk://#diff-97ef185b14216a68c6f92bc5738afca33b78dbd26ac652cbfaeed137264d02a2R54) [[2]](diffhunk://#diff-e970fdfa62e2ac0cfe95c3ccc1f0cea4ba923d1ad0c2f5319e2fb1c586908fd6R315) [[3]](diffhunk://#diff-9fffaf48c082ebff41071e8f7bd581eed5a7b087c6ac98896b1670c890035a0bR24) [[4]](diffhunk://#diff-5f0a163e4127454854a499afcb26dbaba6fc7097a5917622b43db479b3808ee0R50) [[5]](diffhunk://#diff-3ba577c2fb47cd7c4e51241e4d896473c21e0014d7d1a717387dbc66e9285351R95) [[6]](diffhunk://#diff-a8a0f29f83f5cd8df15774fa2baae2fe321c19a6f64095ce774fd46939b9f7e5R47-R48) [[7]](diffhunk://#diff-d55bc2a14f8ffb3a11dd012df65126d083dbfa386d3aab97bfad30c27d6d6fdbR35-R38) [[8]](diffhunk://#diff-6d330c240b62aa2831b25611b9e6ad1b766f1ff5731340ec763110c30afb55a4R45-R49)

**Game Over UI improvements:**

* Updated the Game Over menu (`GameOverMenu.cs` and `game_over_menu.tscn`) to display all tracked session stats in a two-column grid layout, with improved formatting and scaling for better readability. [[1]](diffhunk://#diff-2d12afe22a57db288770fe83a14b8b455f8f42b2caeac66ea5603157a94de103L22-R30) [[2]](diffhunk://#diff-2d12afe22a57db288770fe83a14b8b455f8f42b2caeac66ea5603157a94de103L129-R132) [[3]](diffhunk://#diff-2d12afe22a57db288770fe83a14b8b455f8f42b2caeac66ea5603157a94de103L159-R168) [[4]](diffhunk://#diff-2d12afe22a57db288770fe83a14b8b455f8f42b2caeac66ea5603157a94de103L192-R193) [[5]](diffhunk://#diff-2d12afe22a57db288770fe83a14b8b455f8f42b2caeac66ea5603157a94de103L206-R207) [[6]](diffhunk://#diff-5b777e6eb2a92a9553b68581a909339a20eef41fc2e60ffa66d855b81fbec71bL1-R4) [[7]](diffhunk://#diff-5b777e6eb2a92a9553b68581a909339a20eef41fc2e60ffa66d855b81fbec71bL15-R92)

**Code and UI polish:**

* Reduced font sizes and adjusted panel and label styling for a more compact and visually consistent Game Over screen. [[1]](diffhunk://#diff-5b777e6eb2a92a9553b68581a909339a20eef41fc2e60ffa66d855b81fbec71bL1-R4) [[2]](diffhunk://#diff-2d12afe22a57db288770fe83a14b8b455f8f42b2caeac66ea5603157a94de103L192-R193) [[3]](diffhunk://#diff-2d12afe22a57db288770fe83a14b8b455f8f42b2caeac66ea5603157a94de103L206-R207)

These changes provide players with a richer post-game summary and enable more detailed analytics of gameplay sessions.